### PR TITLE
Couple of small improvements

### DIFF
--- a/api/src/main/scala/org/virtuslab/ideprobe/protocol/BuildResult.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/protocol/BuildResult.scala
@@ -4,12 +4,30 @@ import java.nio.file.Path
 
 case class BuildMessage(file: Option[String], content: String)
 
-case class BuildResult(
-    isAborted: Boolean,
-    errors: Seq[BuildMessage],
-    warnings: Seq[BuildMessage],
-    infos: Seq[BuildMessage],
-    stats: Seq[BuildMessage]
+case class BuildResult(results: Seq[BuildStepResult]) {
+  def hasErrors: Boolean = errors.nonEmpty
+
+  def isAborted: Boolean = merge(_.isAborted)(_ || _)
+
+  def errors: Seq[BuildMessage] = merge(_.errors)(_ ++ _)
+
+  def warnings: Seq[BuildMessage] = merge(_.warnings)(_ ++ _)
+
+  def infos: Seq[BuildMessage] = merge(_.infos)(_ ++ _)
+
+  def stats: Seq[BuildMessage] = merge(_.stats)(_ ++ _)
+
+  private def merge[A](get: BuildStepResult => A)(merge: (A, A) => A): A = {
+    results.map(get).reduce(merge)
+  }
+}
+
+case class BuildStepResult(
+  isAborted: Boolean,
+  errors: Seq[BuildMessage],
+  warnings: Seq[BuildMessage],
+  infos: Seq[BuildMessage],
+  stats: Seq[BuildMessage]
 ) {
   def hasErrors: Boolean = errors.nonEmpty
 }

--- a/api/src/main/scala/org/virtuslab/ideprobe/protocol/FileRef.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/protocol/FileRef.scala
@@ -1,3 +1,5 @@
 package org.virtuslab.ideprobe.protocol
 
-case class FileRef(project: ProjectRef, path: String)
+import java.nio.file.Path
+
+case class FileRef(project: ProjectRef, path: Path)

--- a/api/src/main/scala/org/virtuslab/ideprobe/protocol/NavigationTarget.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/protocol/NavigationTarget.scala
@@ -1,4 +1,4 @@
 package org.virtuslab.ideprobe.protocol
 
-final case class NavigationQuery(project: ProjectRef = ProjectRef.Default, value: String)
+final case class NavigationQuery(value: String, includeNonProjectItems: Boolean = false, project: ProjectRef = ProjectRef.Default)
 final case class NavigationTarget(name: String, location: String)

--- a/driver/bindings/junit/src/main/scala/org/virtuslab/ideprobe/ClassFixtures.scala
+++ b/driver/bindings/junit/src/main/scala/org/virtuslab/ideprobe/ClassFixtures.scala
@@ -1,0 +1,75 @@
+package org.virtuslab.ideprobe
+
+import java.nio.file.Path
+
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.virtuslab.ideprobe.ide.intellij.InstalledIntelliJ
+import org.virtuslab.ideprobe.ide.intellij.RunningIde
+
+trait RunningIntellijPerSuite {
+
+  private var workspace: Path = _
+  private var installed: InstalledIntelliJ = _
+  private var running: RunningIde = _
+  private var runningIntelliJFixture: RunningIntelliJFixture = _
+
+  final def intelliJ: RunningIntelliJFixture = runningIntelliJFixture
+
+  protected def baseFixture: IntelliJFixture
+
+  protected def beforeAll(): Unit = ()
+
+  protected def afterAll(): Unit = ()
+
+  @BeforeClass
+  final def setup(): Unit = {
+    workspace = baseFixture.setupWorkspace()
+    installed = baseFixture.installIntelliJ()
+    running = baseFixture.startIntelliJ(workspace, installed)
+    runningIntelliJFixture = new RunningIntelliJFixture(workspace, running.probe, baseFixture.config, installed.paths)
+    beforeAll()
+  }
+
+  @AfterClass
+  final def teardown(): Unit = {
+    try AfterTestChecks(baseFixture.factory.config.check, runningIntelliJFixture.probe) finally {
+      try afterAll() finally {
+        baseFixture.closeIntellij(running)
+        baseFixture.deleteIntelliJ(installed)
+        baseFixture.deleteWorkspace(workspace)
+      }
+    }
+  }
+}
+
+trait WorkspacePerSuite {
+
+  private var workspacePath: Path = _
+  private var installed: InstalledIntelliJ = _
+  private var runnableIntelliJFixture: RunnableIntelliJFixture = _
+
+  final def workspace: RunnableIntelliJFixture = runnableIntelliJFixture
+
+  protected def baseFixture: IntelliJFixture
+
+  protected def beforeAll(): Unit = ()
+
+  protected def afterAll(): Unit = ()
+
+  @BeforeClass
+  final def setup(): Unit = {
+    workspacePath = baseFixture.setupWorkspace()
+    installed = baseFixture.installIntelliJ()
+    runnableIntelliJFixture = new RunnableIntelliJFixture(workspacePath, installed, baseFixture)
+    beforeAll()
+  }
+
+  @AfterClass
+  final def teardown(): Unit = {
+    try afterAll() finally {
+      baseFixture.deleteIntelliJ(installed)
+      baseFixture.deleteWorkspace(workspacePath)
+    }
+  }
+}

--- a/driver/bindings/junit/src/main/scala/org/virtuslab/ideprobe/IntegrationTestSuite.scala
+++ b/driver/bindings/junit/src/main/scala/org/virtuslab/ideprobe/IntegrationTestSuite.scala
@@ -1,22 +1,28 @@
 package org.virtuslab.ideprobe
 
 import java.util.concurrent.Executors
+
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+
 import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import scala.util.Try
 
 @RunWith(classOf[JUnit4])
 trait IntegrationTestSuite {
   protected implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
 
-  def resourcePath(name: String): String = {
-    s"${getClass.getSimpleName}/$name.conf"
+  def resolveConfig(): Config = {
+    val className = getClass.getSimpleName.stripSuffix("$")
+    val inDirectory = s"$className/ideprobe.conf"
+    val inFile = s"$className.conf"
+    Try(Config.fromClasspath(inFile)).getOrElse(Config.fromClasspath(inDirectory))
   }
 
-  final def fixtureFromConfig(name: String = "ideprobe"): IntelliJFixture = {
-    fixtureFromConfig(Config.fromClasspath(resourcePath(name)))
+  final def fixtureFromConfig(): IntelliJFixture = {
+    fixtureFromConfig(resolveConfig())
   }
 
   final def fixtureFromConfig(config: Config): IntelliJFixture = {

--- a/driver/sources/src/main/scala/org/virtuslab/ideprobe/ProbeDriver.scala
+++ b/driver/sources/src/main/scala/org/virtuslab/ideprobe/ProbeDriver.scala
@@ -112,8 +112,12 @@ final class ProbeDriver(protected val connection: JsonRpcConnection)(implicit pr
 
   def invokeAction(id: String): Unit = send(Endpoints.InvokeAction, id)
 
-  def fileReferences(project: ProjectRef = ProjectRef.Default, path: String): Seq[Reference] = {
+  def fileReferences(project: ProjectRef = ProjectRef.Default, path: Path): Seq[Reference] = {
     send(Endpoints.FileReferences, FileRef(project, path))
+  }
+
+  def fileReferences(fileRef: FileRef): Seq[Reference] = {
+    send(Endpoints.FileReferences, fileRef)
   }
 
   def find(query: NavigationQuery): List[NavigationTarget] = {

--- a/driver/sources/src/main/scala/org/virtuslab/ideprobe/Shell.scala
+++ b/driver/sources/src/main/scala/org/virtuslab/ideprobe/Shell.scala
@@ -13,7 +13,11 @@ import scala.concurrent.Promise
 import scala.concurrent.duration.Duration
 
 object Shell {
-  case class CommandResult(out: String, err: String, exitCode: Int)
+  case class CommandResult(outSafe: String, err: String, exitCode: Int) {
+    def out: String = {
+      if (exitCode != 0) throw new RuntimeException(s"Command failed with exit code $exitCode") else outSafe
+    }
+  }
 
   class ProcessOutputLogger extends NuAbstractProcessHandler {
     private val outputChannel = Channels.newChannel(System.out)

--- a/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/CheckConfig.scala
+++ b/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/CheckConfig.scala
@@ -1,6 +1,6 @@
 package org.virtuslab.ideprobe.ide.intellij
 
-final case class CheckConfig(errors: Boolean = false, freezes: Boolean = true)
+final case class CheckConfig(errors: Boolean = false, freezes: Boolean = false)
 
 object CheckConfig {
   val Disabled: CheckConfig = CheckConfig(false, false)

--- a/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
+++ b/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
@@ -76,7 +76,6 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
   @Test
   def freezeInspector(): Unit =
     fixture
-      .copy(factory = fixture.factory.withConfig(DriverConfig(check = CheckConfig.Disabled)))
       .withDisplay
       .run { intelliJ =>
         intelliJ.probe.invokeAction("org.virtuslab.ideprobe.test.FreezingAction")

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/Builds.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/Builds.scala
@@ -1,7 +1,9 @@
 package org.virtuslab.handlers
 
 import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+
 import com.intellij.openapi.compiler.CompilationStatusListener
 import com.intellij.openapi.compiler.CompileContext
 import com.intellij.openapi.compiler.CompilerMessageCategory
@@ -13,10 +15,7 @@ import com.intellij.util.messages.MessageBusConnection
 import org.virtuslab.ideprobe.protocol.BuildMessage
 import org.virtuslab.ideprobe.protocol.BuildParams
 import org.virtuslab.ideprobe.protocol.BuildResult
-import scala.concurrent.Await
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.concurrent.duration.FiniteDuration
+import org.virtuslab.ideprobe.protocol.BuildStepResult
 
 object Builds extends IntelliJApi {
   def build(params: BuildParams): BuildResult = {
@@ -35,8 +34,8 @@ object Builds extends IntelliJApi {
           buildProject(params, taskManager)
         }
         promise.blockingGet(4, TimeUnit.HOURS)
-        Await.result(collector.buildResult, FiniteDuration(4, TimeUnit.HOURS))
       }
+      collector.buildResult
     } finally {
       connection.disconnect()
     }
@@ -76,11 +75,17 @@ object Builds extends IntelliJApi {
     connection
   }
 
+  // We might get more than one build result form one build. buildResult is called after
+  // there are no background tasks, so all results should already be collected. As we don't
+  // know how many builds were started and background task check might be flaky, there is a
+  // count down latch that will ensure we collect at least one result in such case.
   class BuildResultCollector extends CompilationStatusListener {
-    private val promise = Promise[BuildResult]()
+    private var results: Seq[BuildStepResult] = Nil
+    private val latch = new CountDownLatch(1)
 
-    def buildResult: Future[BuildResult] = {
-      promise.future
+    def buildResult: BuildResult = {
+      latch.await(10, TimeUnit.MINUTES)
+      BuildResult(results)
     }
 
     override def compilationFinished(
@@ -95,7 +100,7 @@ object Builds extends IntelliJApi {
         }
       }
 
-      val buildResult = BuildResult(
+      val buildResult = BuildStepResult(
         aborted,
         messages(CompilerMessageCategory.ERROR),
         messages(CompilerMessageCategory.WARNING),
@@ -103,7 +108,8 @@ object Builds extends IntelliJApi {
         messages(CompilerMessageCategory.STATISTICS)
       )
 
-      promise.success(buildResult)
+      results :+= buildResult
+      latch.countDown()
     }
   }
 }

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/Builds.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/Builds.scala
@@ -75,7 +75,7 @@ object Builds extends IntelliJApi {
     connection
   }
 
-  // We might get more than one build result form one build. buildResult is called after
+  // We might get more than one build result from one build. buildResult is called after
   // there are no background tasks, so all results should already be collected. As we don't
   // know how many builds were started and background task check might be flaky, there is a
   // count down latch that will ensure we collect at least one result in such case.

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/Navigation.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/Navigation.scala
@@ -1,9 +1,11 @@
 package org.virtuslab.handlers
 
 import com.intellij.navigation.ChooseByNameContributor
+import com.intellij.navigation.NavigationItem
 import com.intellij.openapi.project.Project
 import org.virtuslab.ideprobe.protocol.NavigationQuery
 import org.virtuslab.ideprobe.protocol.NavigationTarget
+
 import scala.collection.mutable
 
 object Navigation extends IntelliJApi {
@@ -20,7 +22,9 @@ object Navigation extends IntelliJApi {
     all.toList
   }
 
-  private def findItems(query: NavigationQuery, project: Project, contributor: ChooseByNameContributor) = {
-    read(contributor.getItemsByName(query.value, "", project, false))
+  private def findItems(query: NavigationQuery, project: Project, contributor: ChooseByNameContributor): Array[NavigationItem] = {
+    read {
+      contributor.getItemsByName(query.value, "", project, query.includeNonProjectItems)
+    }
   }
 }

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/PSI.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/PSI.scala
@@ -41,7 +41,7 @@ object PSI extends IntelliJApi {
     Option(element.getProject).map(_.getName).map(ProjectRef(_)).flatMap { project =>
       element match {
         case file: PsiFile =>
-          val path = file.getVirtualFile.getPath
+          val path = VFS.toPath(file.getVirtualFile)
           val ref = Reference.Target.File(FileRef(project, path))
           Some(ref)
         case _ =>

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/VFS.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/VFS.scala
@@ -16,7 +16,7 @@ import scala.util.Try
 object VFS extends IntelliJApi {
 
   def resolve(ref: FileRef): VirtualFile = {
-    toVirtualFile(Paths.get(ref.path))
+    toVirtualFile(ref.path)
   }
 
   def syncAll(): Unit = BackgroundTasks.withAwaitNone {


### PR DESCRIPTION
- Handle multiple "build steps" (one triggered build can result in multiple separate compilation runs).
- Change FileRef to use Path rather than String
- Add `includeNonProjectItems` parameter to NavigationQuery
- Add 2 fixtures to run shared intellij/workspace for whole test suite
- Extend probe configuration lookup logic to support companion objects and TestName.conf (aditionally to TestName/ideprobe.conf)
- Disable failing on freezes by default (needs to be explicitly enabled)
- `CommandResult.out` throws if command failed (similarly to .!! in scala.process._) We often just run a shell command and take the output, in case command fails, we get unexpected or empty output and the problem is hidden. Output can be always read with `outSafe`, yet we don't even need to e.g. log it, as it is always forwarded to console.