### PR TITLE
Allow preconfiguring the jdk

### DIFF
--- a/api/src/main/scala/org/virtuslab/ideprobe/ProbeExtensions.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/ProbeExtensions.scala
@@ -5,14 +5,12 @@ import java.io.BufferedOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.URI
-import java.net.URL
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.util.Comparator
 import java.util.zip.ZipInputStream
-import scala.util.Try
 
 trait ProbeExtensions {
 

--- a/api/src/main/scala/org/virtuslab/ideprobe/protocol/Endpoints.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/protocol/Endpoints.scala
@@ -1,6 +1,7 @@
 package org.virtuslab.ideprobe.protocol
 
 import java.nio.file.Path
+
 import org.virtuslab.ideprobe.jsonrpc.JsonRpc.Method.Notification
 import org.virtuslab.ideprobe.jsonrpc.JsonRpc.Method.Request
 import org.virtuslab.ideprobe.jsonrpc.PayloadJsonFormat._
@@ -9,6 +10,7 @@ import pureconfig.generic.auto._
 object Endpoints {
 
   // commands
+  val PreconfigureJDK = Request[Unit, Unit]("jdk/preconfigure")
   val AwaitIdle = Request[Unit, Unit]("awaitIdle")
   val AwaitNotification = Request[String, IdeNotification]("notification/await")
   val Build = Request[BuildParams, BuildResult]("build")

--- a/driver/sources/src/main/scala/org/virtuslab/ideprobe/ProbeDriver.scala
+++ b/driver/sources/src/main/scala/org/virtuslab/ideprobe/ProbeDriver.scala
@@ -96,6 +96,8 @@ final class ProbeDriver(protected val connection: JsonRpcConnection)(implicit pr
     }
   }
 
+  def preconfigureJDK(): Unit = send(Endpoints.PreconfigureJDK)
+
   /**
    * Forces the probe to wait until all background tasks are complete before processing next request
    */

--- a/probePlugin/src/main/scala/org/virtuslab/BaseProbeHandlerContributor.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/BaseProbeHandlerContributor.scala
@@ -3,6 +3,7 @@ package org.virtuslab
 import org.virtuslab.ProbeHandlers.ProbeHandler
 import org.virtuslab.handlers._
 import org.virtuslab.ideprobe.protocol.Endpoints
+
 import scala.concurrent.ExecutionContext
 
 class BaseProbeHandlerContributor extends ProbeHandlerContributor {
@@ -10,6 +11,7 @@ class BaseProbeHandlerContributor extends ProbeHandlerContributor {
 
   override def registerHandlers(handler: ProbeHandler): ProbeHandler = {
     handler
+      .on(Endpoints.PreconfigureJDK)(_ => JDK.preconfigure())
       .on(Endpoints.PID)(_ => App.pid)
       .on(Endpoints.Ping)(_ => ())
       .on(Endpoints.Plugins)(_ => Plugins.list)

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/JDK.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/JDK.scala
@@ -1,0 +1,9 @@
+package org.virtuslab.handlers
+
+import com.intellij.openapi.projectRoots.ProjectJdkTable
+
+object JDK extends IntelliJApi {
+  def preconfigure(): Unit = runOnUISync {
+    ProjectJdkTable.getInstance().preconfigure()
+  }
+}


### PR DESCRIPTION
Can be used before importing scala project, since currently it does not work due to a lack of a predefined jdk