### PR TITLE
Add read action for item.getName

### DIFF
--- a/probePlugin/src/main/scala/org/virtuslab/handlers/Navigation.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/Navigation.scala
@@ -15,7 +15,7 @@ object Navigation extends IntelliJApi {
 
     ChooseByNameContributor.CLASS_EP_NAME.forEachExtensionSafe { contributor =>
       findItems(query, project, contributor)
-        .map(item => NavigationTarget(item.getName, item.getPresentation.getLocationString))
+        .map(item => read { NavigationTarget(item.getName, item.getPresentation.getLocationString) })
         .foreach(all += _)
     }
 


### PR DESCRIPTION
It throws in thrift plugin test as `getName` is accessing psi