### PR TITLE
Improve usability of content roots api

### DIFF
--- a/api/src/main/scala/org/virtuslab/ideprobe/protocol/Project.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/protocol/Project.scala
@@ -2,13 +2,6 @@ package org.virtuslab.ideprobe.protocol
 
 import java.nio.file.Path
 
-import org.virtuslab.ideprobe.ConfigFormat
-import org.virtuslab.ideprobe.jsonrpc.PayloadJsonFormat._
-import org.virtuslab.ideprobe.protocol.ContentRoot.{MainResources, MainSources, TestResources, TestSources}
-import pureconfig.error.CannotConvert
-import pureconfig.generic.auto._
-import pureconfig.{ConfigReader, ConfigWriter}
-
 case class Project(
     name: String,
     basePath: String,
@@ -16,37 +9,17 @@ case class Project(
 )
 
 case class Module(name: String,
-                  contentRoots: Map[ContentRoot, Set[Path]],
+                  contentRoots: ContentRoots,
                   dependencies: Set[ModuleRef],
                   kind: Option[String])
 
-object Module extends ConfigFormat {
-  implicit val reader: ConfigReader[Module] = exportReader[Module].instance
-  implicit val writer: ConfigWriter[Module] = exportWriter[Module].instance
-
-  import pureconfig._
-  import pureconfig.configurable._
-
-  implicit val contentRootsReader: ConfigReader[Map[ContentRoot, Set[Path]]] =
-    genericMapReader[ContentRoot, Set[Path]] {
-      case "MainSources"   => Right(MainSources)
-      case "MainResources" => Right(MainResources)
-      case "TestSources"   => Right(TestSources)
-      case "TestResources" => Right(TestResources)
-      case other           => Left(CannotConvert(other, ContentRoot.getClass.getSimpleName, "Not supported"))
-    }
-
-  implicit val contentRootsWriter: ConfigWriter[Map[ContentRoot, Set[Path]]] =
-    genericMapWriter[ContentRoot, Set[Path]](_.toString)
-
-}
-
-sealed trait ContentRoot
-object ContentRoot extends ConfigFormat {
-  case object MainSources extends ContentRoot
-  case object MainResources extends ContentRoot
-  case object TestSources extends ContentRoot
-  case object TestResources extends ContentRoot
-
-  val All = Seq(MainSources, MainResources, TestSources, TestResources)
+case class ContentRoots(
+  sources: Set[Path],
+  resources: Set[Path],
+  testSources: Set[Path],
+  testResources: Set[Path]
+) {
+  def allSources: Set[Path] = sources ++ testSources
+  def allResources: Set[Path] = resources ++ testResources
+  def all: Set[Path] = allSources ++ allResources
 }

--- a/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
+++ b/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
@@ -7,17 +7,13 @@ import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe.dependencies.IntelliJVersion
 import org.virtuslab.ideprobe.dependencies.Plugin
 import org.virtuslab.ideprobe.jsonrpc.RemoteException
-import org.virtuslab.ideprobe.protocol.ContentRoot.MainResources
-import org.virtuslab.ideprobe.protocol.ContentRoot.MainSources
-import org.virtuslab.ideprobe.protocol.ContentRoot.TestResources
-import org.virtuslab.ideprobe.protocol.ContentRoot.TestSources
-import org.virtuslab.ideprobe.protocol.TestStatus.Passed
 import org.virtuslab.ideprobe.protocol.BuildScope
 import org.virtuslab.ideprobe.protocol.InstalledPlugin
 import org.virtuslab.ideprobe.protocol.JUnitRunConfiguration
 import org.virtuslab.ideprobe.protocol.ModuleRef
 import org.virtuslab.ideprobe.protocol.ProjectRef
 import org.virtuslab.ideprobe.protocol.TestStatus
+import org.virtuslab.ideprobe.protocol.TestStatus.Passed
 import org.virtuslab.ideprobe.protocol.VcsRoot
 
 import scala.concurrent.duration._
@@ -115,10 +111,10 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
       val mainModule = model.modules.find(_.name == "foo.main").get
       val testModule = model.modules.find(_.name == "foo.test").get
 
-      assertEquals(Set(src.resolve("main/java")), mainModule.contentRoots(MainSources))
-      assertEquals(Set(src.resolve("main/resources")), mainModule.contentRoots(MainResources))
-      assertEquals(Set(src.resolve("test/java")), testModule.contentRoots(TestSources))
-      assertEquals(Set(src.resolve("test/resources")), testModule.contentRoots(TestResources))
+      assertEquals(Set(src.resolve("main/java")), mainModule.contentRoots.sources)
+      assertEquals(Set(src.resolve("main/resources")), mainModule.contentRoots.resources)
+      assertEquals(Set(src.resolve("test/java")), testModule.contentRoots.testSources)
+      assertEquals(Set(src.resolve("test/resources")), testModule.contentRoots.testResources)
     }
   }
 

--- a/probePlugin/src/main/scala/org/virtuslab/ProbePluginExtensions.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/ProbePluginExtensions.scala
@@ -4,13 +4,19 @@ import java.nio.file.Path
 
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.roots.ModuleRootManager
-import org.jetbrains.jps.model.java.JavaResourceRootType.{RESOURCE, TEST_RESOURCE}
-import org.jetbrains.jps.model.java.JavaSourceRootType.{SOURCE, TEST_SOURCE}
+import org.jetbrains.jps.model.java.JavaResourceRootType.RESOURCE
+import org.jetbrains.jps.model.java.JavaResourceRootType.TEST_RESOURCE
+import org.jetbrains.jps.model.java.JavaSourceRootType.SOURCE
+import org.jetbrains.jps.model.java.JavaSourceRootType.TEST_SOURCE
+import org.jetbrains.jps.model.module.JpsModuleSourceRootType
 import org.virtuslab.handlers.VFS
-import org.virtuslab.ideprobe.protocol.{ContentRoot, ModuleRef, ProjectRef}
 import org.virtuslab.ideprobe.Extensions._
+import org.virtuslab.ideprobe.protocol.ContentRoots
+import org.virtuslab.ideprobe.protocol.ModuleRef
+import org.virtuslab.ideprobe.protocol.ProjectRef
 
 object ProbePluginExtensions {
+
   final implicit class ModuleExtension(module: Module) {
     def toRef: ModuleRef = {
       val project = module.getProject
@@ -19,17 +25,18 @@ object ProbePluginExtensions {
 
     def dependencies: Array[Module] = roots.getDependencies
 
-    def contentRoots(kind: ContentRoot): Set[Path] = {
-      val rootType = kind match {
-        case ContentRoot.MainSources   => SOURCE
-        case ContentRoot.MainResources => RESOURCE
-        case ContentRoot.TestSources   => TEST_SOURCE
-        case ContentRoot.TestResources => TEST_RESOURCE
-      }
+    def contentRoots: ContentRoots = {
+      def by(rootType: JpsModuleSourceRootType[_]): Set[Path] = roots.getSourceRoots(rootType).asScala.map(VFS.toPath).toSet
 
-      roots.getSourceRoots(rootType).asScala.map(VFS.toPath).toSet
+      ContentRoots(
+        sources = by(SOURCE),
+        resources = by(RESOURCE),
+        testSources = by(TEST_SOURCE),
+        testResources = by(TEST_RESOURCE),
+      )
     }
 
     def roots: ModuleRootManager = ModuleRootManager.getInstance(module)
   }
+
 }

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/Projects.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/Projects.scala
@@ -1,26 +1,20 @@
 package org.virtuslab.handlers
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
 
 import com.intellij.ide.actions.ImportModuleAction
 import com.intellij.ide.impl.ProjectUtil
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.projectImport.ProjectImportProvider
-import org.jetbrains.jps.model.module.JpsModuleSourceRootType
-import org.virtuslab.handlers.Modules.resolve
+import org.virtuslab.ProbePluginExtensions._
+import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe.protocol
-import org.virtuslab.ideprobe.protocol.{ContentRoot, ModuleRef, ProjectRef}
+import org.virtuslab.ideprobe.protocol.ProjectRef
 
 import scala.annotation.tailrec
-import org.virtuslab.ideprobe.Extensions._
-import org.virtuslab.ProbePluginExtensions._
-import org.virtuslab.ideprobe.protocol.ContentRoot._
-
-import scala.collection.mutable
 
 object Projects extends IntelliJApi {
 
@@ -95,14 +89,8 @@ object Projects extends IntelliJApi {
     val project = resolve(ref)
     val modules = ModuleManager.getInstance(project).getSortedModules
     val mappedModules = modules.map { module =>
-      val roots: Map[ContentRoot, Set[Path]] = ContentRoot.All
-        .map(root => root -> module.contentRoots(root))
-        .filterNot(_._2.isEmpty)
-        .toMap
-
       val dependencies = module.dependencies.map(_.toRef).toSet
-
-      protocol.Module(module.getName, roots, dependencies, Option(module.getModuleTypeName))
+      protocol.Module(module.getName, module.contentRoots, dependencies, Option(module.getModuleTypeName))
     }
 
     protocol.Project(project.getName, project.getBasePath, mappedModules)


### PR DESCRIPTION
I used plain case class instead of map with custom types. The original solution was not extensible anyway, now there still is one file that needs to be changed. Additionally we can use default generic derivation of config without extra codecs.
Also api is more convenient:
* no need for `contentRoots.getOrElse(MainSources, Set.empty[Path])`
* no need to import ContentRoot
* no need to contentRoots.values.flatten to inspect all content roots at once