### PR TITLE
Extend Sdk api

### DIFF
--- a/api/src/main/scala/org/virtuslab/ideprobe/protocol/Endpoints.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/protocol/Endpoints.scala
@@ -32,11 +32,11 @@ object Endpoints {
   val Freezes = Request[Unit, Seq[Freeze]]("freezes")
   val ListOpenProjects = Request[Unit, Seq[ProjectRef]]("projects/all")
   val Messages = Request[Unit, Seq[IdeMessage]]("messages")
-  val ModuleSdk = Request[ModuleRef, Option[String]]("module/sdk")
+  val ModuleSdk = Request[ModuleRef, Option[Sdk]]("module/sdk")
   val PID = Request[Unit, Long]("pid")
   val Ping = Request[Unit, Unit]("ping")
   val Plugins = Request[Unit, Seq[InstalledPlugin]]("plugins")
-  val ProjectSdk = Request[ProjectRef, Option[String]]("project/sdk")
+  val ProjectSdk = Request[ProjectRef, Option[Sdk]]("project/sdk")
   val ProjectModel = Request[ProjectRef, Project]("project/model")
   val VcsRoots = Request[ProjectRef, Seq[VcsRoot]]("project/vcsRoots")
 }

--- a/api/src/main/scala/org/virtuslab/ideprobe/protocol/Sdk.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/protocol/Sdk.scala
@@ -1,0 +1,10 @@
+package org.virtuslab.ideprobe.protocol
+
+import java.nio.file.Path
+
+case class Sdk(
+  name: String,
+  typeId: String,
+  version: Option[String],
+  homePath: Option[Path]
+)

--- a/driver/sources/src/main/scala/org/virtuslab/ideprobe/ProbeDriver.scala
+++ b/driver/sources/src/main/scala/org/virtuslab/ideprobe/ProbeDriver.scala
@@ -40,6 +40,7 @@ import scala.reflect.ClassTag
 import scala.util.Failure
 import scala.util.Try
 import RobotExtensions._
+import org.virtuslab.ideprobe.protocol.Sdk
 
 final class ProbeDriver(
   protected val connection: JsonRpcConnection,
@@ -230,12 +231,12 @@ final class ProbeDriver(
   /**
    * Returns the sdk of the specified project
    */
-  def projectSdk(project: ProjectRef = ProjectRef.Default): Option[String] = send(Endpoints.ProjectSdk, project)
+  def projectSdk(project: ProjectRef = ProjectRef.Default): Option[Sdk] = send(Endpoints.ProjectSdk, project)
 
   /**
    * Returns the sdk of the specified module
    */
-  def moduleSdk(module: ModuleRef): Option[String] = send(Endpoints.ModuleSdk, module)
+  def moduleSdk(module: ModuleRef): Option[Sdk] = send(Endpoints.ModuleSdk, module)
 
   /**
    * Returns the list of VCS roots of the specified project

--- a/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
+++ b/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
@@ -1,6 +1,10 @@
 package org.virtuslab.ideprobe
 
+import java.net.URL
+import java.nio.charset.Charset
+
 import com.intellij.remoterobot.utils.WaitForConditionTimeoutException
+import org.apache.commons.io.IOUtils
 import org.junit.Assert._
 import org.junit.Ignore
 import org.junit.Test
@@ -243,7 +247,7 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
 
     val newProjectDialog = retry(3) {
       welcomeFrame.actionLink("New Project").click()
-      welcomeFrame.find(query.dialog("New Project"))
+      intelliJ.probe.robot.find(query.dialog("New Project"))
     }
     val dialogContent = newProjectDialog.fullText
 
@@ -251,6 +255,7 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
     assertTrue(s"New Project dialog content: '$dialogContent' did not contain '$projectSdk'", dialogContent.contains(projectSdk))
   }
 
+  // temporary for debugging
   @tailrec
   private def retry[A](times: Int)(action: => A): A = {
     try {
@@ -260,6 +265,9 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
         if (times > 0) {
           println("Failed to find element, retrying...")
           e.printStackTrace()
+          try println(IOUtils.toString(new URL("http://localhost:9534/"), Charset.defaultCharset())) catch {
+            case e: Exception => e.printStackTrace()
+          }
           retry(times - 1)(action)
         } else {
           throw e

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/Modules.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/Modules.scala
@@ -1,31 +1,30 @@
 package org.virtuslab.handlers
 
-import com.intellij.openapi.module.{Module, ModuleManager}
-import com.intellij.openapi.project.Project
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.roots.ModuleRootManager
-import org.virtuslab.ideprobe.protocol.{ModuleRef, ProjectRef}
+import org.virtuslab.ideprobe.protocol.ModuleRef
+import org.virtuslab.ideprobe.protocol.Sdk
 
 object Modules extends IntelliJApi {
-  def resolve(module: ModuleRef): (Project, Module) = {
+  def resolve(module: ModuleRef): Module = {
     val project = Projects.resolve(module.project)
     val modules = ModuleManager.getInstance(project).getModules
-
     modules.find(_.getName == module.name) match {
       case Some(module) =>
-        (project, module)
+        module
       case None =>
         val helpMessage =
           if (modules.isEmpty) "There are no open modules"
           else s"Available modules are: ${modules.map(_.getName).mkString(",")}"
 
         error(s"Could not find module [${module.name}] inside project [${module.name}]. $helpMessage")
-
     }
   }
 
-  def sdk(moduleRef: ModuleRef): Option[String] = {
-    val (_, module) = resolve(moduleRef)
+  def sdk(moduleRef: ModuleRef): Option[Sdk] = {
+    val module = resolve(moduleRef)
     val sdk = ModuleRootManager.getInstance(module).getSdk
-    Option(sdk).map(_.getName)
+    Option(sdk).map(Sdks.convert)
   }
 }

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/Projects.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/Projects.scala
@@ -13,6 +13,7 @@ import org.virtuslab.ProbePluginExtensions._
 import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe.protocol
 import org.virtuslab.ideprobe.protocol.ProjectRef
+import org.virtuslab.ideprobe.protocol.Sdk
 
 import scala.annotation.tailrec
 
@@ -96,10 +97,10 @@ object Projects extends IntelliJApi {
     protocol.Project(project.getName, project.getBasePath, mappedModules)
   }
 
-  def sdk(ref: ProjectRef): Option[String] = read {
+  def sdk(ref: ProjectRef): Option[Sdk] = read {
     val project = resolve(ref)
     val sdk = ProjectRootManager.getInstance(project).getProjectSdk
-    Option(sdk).map(_.getName)
+    Option(sdk).map(Sdks.convert)
   }
 
   private def findProject(name: String): Project = {

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/RunConfigurations.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/RunConfigurations.scala
@@ -33,7 +33,8 @@ import org.virtuslab.ideprobe.Extensions._
 
 object RunConfigurations extends IntelliJApi {
   def execute(runConfiguration: JUnitRunConfiguration)(implicit ec: ExecutionContext): TestsRunResult = {
-    val (project, module) = Modules.resolve(runConfiguration.module)
+    val module = Modules.resolve(runConfiguration.module)
+    val project = module.getProject
 
     val configuration = new JUnitConfiguration(UUID.randomUUID().toString, project)
     configuration.setModule(module)
@@ -119,7 +120,8 @@ object RunConfigurations extends IntelliJApi {
   private def registerObservableConfiguration(
       mainClass: ApplicationRunConfiguration
   ): RunnerSettingsWithProcessOutput = {
-    val (project, module) = Modules.resolve(mainClass.module)
+    val module = Modules.resolve(mainClass.module)
+    val project = module.getProject
 
     val configuration = {
       val psiClass = {

--- a/probePlugin/src/main/scala/org/virtuslab/handlers/Sdks.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/handlers/Sdks.scala
@@ -1,0 +1,17 @@
+package org.virtuslab.handlers
+
+import java.nio.file.Paths
+
+import org.virtuslab.ideprobe.protocol
+import com.intellij.openapi.projectRoots.Sdk
+
+object Sdks {
+  def convert(sdk: Sdk): protocol.Sdk = {
+    protocol.Sdk(
+      sdk.getName,
+      sdk.getSdkType.toString,
+      Option(sdk.getVersionString),
+      Option(sdk.getHomePath).map(Paths.get(_))
+    )
+  }
+}


### PR DESCRIPTION
* Replace Sdk with proper type
* Remove project from `Modules.resolve`, as we care about `Module` (also avoiding unpacking tuple each time), and Module always has `getProject`, which is more reliable than our resolve.
* Another attempt on fixing robot test