### PR TITLE
Allow reusing existing workspace

### DIFF
--- a/driver/bindings/junit/src/main/scala/org/virtuslab/ideprobe/WorkspaceConfig.scala
+++ b/driver/bindings/junit/src/main/scala/org/virtuslab/ideprobe/WorkspaceConfig.scala
@@ -1,5 +1,6 @@
 package org.virtuslab.ideprobe
 
+import java.nio.file.Path
 import org.virtuslab.ideprobe.dependencies.Resource
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
@@ -25,12 +26,15 @@ object WorkspaceConfig extends ConfigFormat {
 
   case class Default(path: Resource) extends WorkspaceConfig
 
+  case class Existing(existing: Path) extends WorkspaceConfig
+
   implicit val workspaceConfigReader: ConfigReader[WorkspaceConfig] = {
     possiblyAmbiguousAdtReader[WorkspaceConfig](
       deriveReader[GitBranch],
       deriveReader[GitTag],
       deriveReader[GitCommit],
-      deriveReader[Default]
+      deriveReader[Default],
+      deriveReader[Existing]
     )
   }
 }

--- a/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
+++ b/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
@@ -56,7 +56,7 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
   @Test
   def projectOpen(): Unit =
     fixture
-      .copy(workspaceTemplate = WorkspaceTemplate.FromResource("OpenProjectTest"))
+      .copy(workspaceProvider = WorkspaceTemplate.FromResource("OpenProjectTest"))
       .run { intelliJ =>
         val expectedProjectName = "empty-project"
         val projectPath = intelliJ.workspace.resolve(expectedProjectName)
@@ -88,12 +88,12 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
     }
   }
 
-  private val buildTestFixture = fixture.copy(workspaceTemplate = WorkspaceTemplate.FromResource("BuildTest"))
+  private val buildTestFixture = fixture.copy(workspaceProvider = WorkspaceTemplate.FromResource("BuildTest"))
 
   @Test
   def vcsDetection(): Unit = {
     fixture
-      .copy(workspaceTemplate = WorkspaceTemplate.FromResource("OpenProjectTest"))
+      .copy(workspaceProvider = WorkspaceTemplate.FromResource("OpenProjectTest"))
       .withWorkspace { workspace =>
         val projectDir = workspace.path.resolve("empty-project")
         Shell.run(in = projectDir, "git", "init")
@@ -107,7 +107,7 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
 
   @Test
   def listsAllSourceRoots(): Unit = {
-    fixture.copy(workspaceTemplate = WorkspaceTemplate.FromResource("gradle-project")).run { intelliJ =>
+    fixture.copy(workspaceProvider = WorkspaceTemplate.FromResource("gradle-project")).run { intelliJ =>
       val projectDir = intelliJ.workspace.resolve("build.gradle")
       val src = intelliJ.workspace.resolve("src")
 
@@ -126,7 +126,7 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
 
   @Test
   def listsModuleDependencies(): Unit = {
-    fixture.copy(workspaceTemplate = WorkspaceTemplate.FromResource("gradle-project")).run { intelliJ =>
+    fixture.copy(workspaceProvider = WorkspaceTemplate.FromResource("gradle-project")).run { intelliJ =>
       val projectDir = intelliJ.workspace.resolve("build.gradle")
       val p = intelliJ.probe.openProject(projectDir)
 
@@ -153,7 +153,7 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
         val failedResult = intelliJ.probe.build()
         assertExists(failedResult.errors) { error =>
           error.file.exists(_.endsWith("src/main/scala/Main.scala")) &&
-            error.content.contains("expected class or object definition")
+          error.content.contains("expected class or object definition")
         }
       }
   }
@@ -252,7 +252,10 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
     val dialogContent = newProjectDialog.fullText
 
     val projectSdk = "Project SDK"
-    assertTrue(s"New Project dialog content: '$dialogContent' did not contain '$projectSdk'", dialogContent.contains(projectSdk))
+    assertTrue(
+      s"New Project dialog content: '$dialogContent' did not contain '$projectSdk'",
+      dialogContent.contains(projectSdk)
+    )
   }
 
   // temporary for debugging
@@ -265,7 +268,8 @@ final class ProbeDriverTest extends IntegrationTestSuite with Assertions {
         if (times > 0) {
           println("Failed to find element, retrying...")
           e.printStackTrace()
-          try println(IOUtils.toString(new URL("http://localhost:9534/"), Charset.defaultCharset())) catch {
+          try println(IOUtils.toString(new URL("http://localhost:9534/"), Charset.defaultCharset()))
+          catch {
             case e: Exception => e.printStackTrace()
           }
           retry(times - 1)(action)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.6.0")
+addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.7.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")


### PR DESCRIPTION
Useful if we don't care about multiple tests interacting with the same workspace (e.g. if each test cleanups after itself or doesn't write anything that can affect other tests). Also useful when setting up repo is costly and/or custom, so it can be prepared externally.