### PR TITLE
Delete the empty parent directory after the workspace is deleted

### DIFF
--- a/driver/bindings/junit/src/main/scala/org/virtuslab/ideprobe/WorkspaceProvider.scala
+++ b/driver/bindings/junit/src/main/scala/org/virtuslab/ideprobe/WorkspaceProvider.scala
@@ -63,7 +63,10 @@ sealed trait WorkspaceTemplate extends WorkspaceProvider {
     workspace
   }
 
-  override def cleanup(path: Path): Unit = path.delete()
+  override def cleanup(path: Path): Unit = {
+    path.delete()
+    path.getParent.delete()
+  }
 
   def setupIn(workspace: Path): Unit
 }


### PR DESCRIPTION
This pull request reduces the clutter in the `/tmp` directory by deleting the leftover empty base directories.

Since the base directory is created along with the workspace directory, I believe it is appropriate to delete it along with the workspace too.

This pull request is related to the issue #22.