### PR TITLE
Encode UUIDs with Base 64

### DIFF
--- a/api/src/main/scala/org/virtuslab/ideprobe/ProbeExtensions.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/ProbeExtensions.scala
@@ -13,7 +13,6 @@ import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
-import java.util.UUID
 import java.util.zip.ZipInputStream
 import scala.util.Failure
 import scala.util.Try
@@ -61,8 +60,7 @@ trait ProbeExtensions {
     }
 
     def createTempDirectory(prefix: String): Path = {
-      val suffix = UUID.randomUUID.toString
-      path.resolve(prefix + suffix)
+      path.resolve(s"$prefix-${UUIDs.randomUUID()}")
     }
 
     def copyTo(target: Path): Path = {

--- a/api/src/main/scala/org/virtuslab/ideprobe/UUIDs.scala
+++ b/api/src/main/scala/org/virtuslab/ideprobe/UUIDs.scala
@@ -1,0 +1,19 @@
+package org.virtuslab.ideprobe
+
+import java.nio.ByteBuffer
+import java.util.{Base64, UUID}
+
+object UUIDs {
+
+  // Copied from https://stackoverflow.com/a/29836273
+
+  def toBase64String(uuid: UUID): String = {
+    val bb = ByteBuffer.wrap(new Array[Byte](16))
+    bb.putLong(uuid.getMostSignificantBits)
+    bb.putLong(uuid.getLeastSignificantBits)
+    Base64.getUrlEncoder.encodeToString(bb.array)
+  }
+
+  def randomUUID(): String = toBase64String(UUID.randomUUID)
+
+}

--- a/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/RunConfigurations.scala
+++ b/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/RunConfigurations.scala
@@ -14,8 +14,8 @@ import com.intellij.openapi.project.{DumbService, Project}
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.{JavaPsiFacade, PsiClass, PsiElement}
 import com.intellij.testFramework.MapDataContext
-import java.util.{Collections, UUID}
-import org.virtuslab.ideprobe.{RunConfigurationTransformer, RunnerSettingsWithProcessOutput}
+import java.util.Collections
+import org.virtuslab.ideprobe.{RunConfigurationTransformer, RunnerSettingsWithProcessOutput, UUIDs}
 import org.virtuslab.ideprobe.protocol._
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.concurrent.ExecutionContext
@@ -87,7 +87,7 @@ object RunConfigurations extends IntelliJApi {
     val module = Modules.resolve(scope.module)
     val project = module.getProject
 
-    val configuration = new JUnitConfiguration(UUID.randomUUID().toString, project)
+    val configuration = new JUnitConfiguration(UUIDs.randomUUID(), project)
     configuration.setModule(module)
     val data = configuration.getPersistentData
     scope match {
@@ -132,8 +132,7 @@ object RunConfigurations extends IntelliJApi {
     val project = module.getProject
 
     val configuration = {
-      val name = UUID.randomUUID()
-      val configuration = new ApplicationConfiguration(name.toString, project)
+      val configuration = new ApplicationConfiguration(UUIDs.randomUUID(), project)
       configuration.setModule(module)
       configuration.setMainClassName(appRunConfig.mainClass)
       if (appRunConfig.args.nonEmpty) {


### PR DESCRIPTION
The motivation, purpose and implementation is exactly same as in https://github.com/scalacenter/bloop/pull/851.

Before: `/tmp/workspaces/ideprobe-workspacea5aabeda-930c-422e-8c68-ab9bce1bf81a/ws`
After: `/tmp/workspaces/ideprobe-workspace-uAVmccQ9SZ6SVESwNdmDSw==/ws`