### PR TITLE
Adding semi-automatic configuration parser for TestScope

### DIFF
--- a/core/api/src/main/scala/org/virtuslab/ideprobe/ConfigFormat.scala
+++ b/core/api/src/main/scala/org/virtuslab/ideprobe/ConfigFormat.scala
@@ -35,7 +35,7 @@ trait ConfigFormat {
   // or { type = filesystem, path = "/tmp" }. It is more convenient for users, especially for such
   // common classes if we can differentiate what class it is by set of fields. We just have to be sure
   // to not introduce e.g. 2 classes with single field 'path'.
-  def possiblyAmbiguousAdtReader[Base](readers: ConfigReader[_]*)(implicit ct: ClassTag[Base]): ConfigReader[Base] =
+  protected def possiblyAmbiguousAdtReader[Base](readers: ConfigReader[_]*)(implicit ct: ClassTag[Base]): ConfigReader[Base] =
     (cur: ConfigCursor) => {
       val read = readers.map(_.from(cur)).asInstanceOf[Seq[Result[Base]]]
 

--- a/core/api/src/main/scala/org/virtuslab/ideprobe/protocol/ModuleRef.scala
+++ b/core/api/src/main/scala/org/virtuslab/ideprobe/protocol/ModuleRef.scala
@@ -1,9 +1,15 @@
 package org.virtuslab.ideprobe.protocol
 
+import org.virtuslab.ideprobe.ConfigFormat
+import pureconfig.ConfigConvert
+import pureconfig.generic.semiauto.deriveConvert
+
 final case class ModuleRef(name: String, project: ProjectRef = ProjectRef.Default)
 
-object ModuleRef {
+object ModuleRef extends ConfigFormat {
   def apply(name: String, project: String): ModuleRef = {
     ModuleRef(name, ProjectRef(project))
   }
+
+  implicit val moduleRefConvert: ConfigConvert[ModuleRef] = deriveConvert[ModuleRef]
 }

--- a/core/api/src/main/scala/org/virtuslab/ideprobe/protocol/ProjectRef.scala
+++ b/core/api/src/main/scala/org/virtuslab/ideprobe/protocol/ProjectRef.scala
@@ -1,10 +1,34 @@
 package org.virtuslab.ideprobe.protocol
 
+import com.typesafe.config.ConfigValueFactory
+import org.virtuslab.ideprobe.ConfigFormat
+import pureconfig.generic.semiauto.{deriveReader, deriveWriter}
+import pureconfig.{ConfigReader, ConfigWriter}
+
 sealed trait ProjectRef
 
-object ProjectRef {
+object ProjectRef extends ConfigFormat {
   case object Default extends ProjectRef
   case class ByName(name: String) extends ProjectRef
 
   def apply(name: String): ProjectRef = ByName(name)
+
+  private val defaultProjectRefConfigReader: ConfigReader[Default.type] =
+    ConfigReader.fromStringOpt(s => if (s.toLowerCase == "default") Some(Default) else None)
+
+  implicit val projectRefConfigReader: ConfigReader[ProjectRef] = {
+    possiblyAmbiguousAdtReader(
+      deriveReader[ByName],
+      defaultProjectRefConfigReader
+    )
+  }
+
+  implicit val projectRefConfigWriter: ConfigWriter[ProjectRef] = {
+    possiblyAmbiguousAdtWriter(
+      deriveWriter[ByName],
+      ConfigWriter.fromFunction[Default.type] { _ =>
+        ConfigValueFactory.fromAnyRef("default")
+      }
+    )
+  }
 }

--- a/core/api/src/main/scala/org/virtuslab/ideprobe/protocol/TestScope.scala
+++ b/core/api/src/main/scala/org/virtuslab/ideprobe/protocol/TestScope.scala
@@ -1,11 +1,35 @@
 package org.virtuslab.ideprobe.protocol
 
+import org.virtuslab.ideprobe.ConfigFormat
+import pureconfig.{ConfigReader, ConfigWriter}
+import pureconfig.generic.semiauto.{deriveReader, deriveWriter}
+
 sealed abstract class TestScope(val module: ModuleRef)
 
-object TestScope {
+object TestScope extends ConfigFormat {
   case class Module(override val module: ModuleRef) extends TestScope(module)
   case class Directory(override val module: ModuleRef, directoryName: String) extends TestScope(module)
   case class Package(override val module: ModuleRef, packageName: String) extends TestScope(module)
   case class Class(override val module: ModuleRef, className: String) extends TestScope(module)
   case class Method(override val module: ModuleRef, className: String, methodName: String) extends TestScope(module)
+
+  implicit val testScopeConfigReader: ConfigReader[TestScope] = {
+    possiblyAmbiguousAdtReader[TestScope](
+      deriveReader[Method],
+      deriveReader[Class],
+      deriveReader[Package],
+      deriveReader[Directory],
+      deriveReader[Module],
+    )
+  }
+
+  implicit val testScopeConfigWriter: ConfigWriter[TestScope] = {
+    possiblyAmbiguousAdtWriter[TestScope](
+      deriveWriter[Method],
+      deriveWriter[Class],
+      deriveWriter[Package],
+      deriveWriter[Directory],
+      deriveWriter[Module],
+    )
+  }
 }

--- a/core/api/src/test/scala/org/virtuslab/ideprobe/TestScopeParsingTest.scala
+++ b/core/api/src/test/scala/org/virtuslab/ideprobe/TestScopeParsingTest.scala
@@ -1,0 +1,50 @@
+package org.virtuslab.ideprobe
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.virtuslab.ideprobe.protocol.{ModuleRef, TestScope}
+
+@RunWith(classOf[JUnit4])
+final class TestScopeParsingTest {
+
+  private def testParsing(confString: String): TestScope =
+    Config.fromString(confString).as[TestScope]
+
+  @Test
+  def parseModuleWithDefaultProject(): Unit = {
+    val scope = testParsing("""{ module: { name: "moduleName", project: "default" }}""")
+    assertEquals(scope, TestScope.Module(ModuleRef("moduleName")))
+  }
+
+  @Test
+  def parseModuleWithNamedProject(): Unit = {
+    val scope = testParsing("""{ module: { name: "moduleName", project: { name: "Name" } }}""")
+    assertEquals(scope, TestScope.Module(ModuleRef("moduleName", "Name")))
+  }
+
+  @Test
+  def parseDirectory(): Unit = {
+    val scope = testParsing("""{ module: { name: "moduleName" }, directoryName: "/tmp" }""")
+    assertEquals(scope, TestScope.Directory(ModuleRef("moduleName"), "/tmp"))
+  }
+
+  @Test
+  def parsePackage(): Unit = {
+    val scope = testParsing("""{ module: { name: "moduleName" }, packageName: "Package" }""")
+    assertEquals(scope, TestScope.Package(ModuleRef("moduleName"), "Package"))
+  }
+
+  @Test
+  def parseClass(): Unit = {
+    val scope = testParsing("""{ module: { name: "moduleName" }, className: "Class" }""")
+    assertEquals(scope, TestScope.Class(ModuleRef("moduleName"), "Class"))
+  }
+
+  @Test
+  def parseMethod(): Unit = {
+    val scope = testParsing("""{ module: { name: "moduleName" }, className: "Class", methodName: "Method" }""")
+    assertEquals(scope, TestScope.Method(ModuleRef("moduleName"), "Class", "Method"))
+  }
+}


### PR DESCRIPTION
This PR adds semi-automatic PureConfig readers for TestScope and all it's components