### PR TITLE
Adding plugin version switcher to probe drivers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val driver = module("driver", "core/driver/sources")
   .dependsOn(api)
 
 lazy val driver213 = driver(scala213)
-  .usesIdeaPlugin(probePlugin213)
+  .usesIdeaPlugins(probePlugin213, probePlugin212)
 
 lazy val robotDriver = module("robot-driver", "extensions/robot/driver")
   .enablePlugins(BuildInfoPlugin)
@@ -113,7 +113,7 @@ lazy val driverTests = testModule("driver-tests", "core/driver/tests").cross
   .dependsOn(junitDriver, robotDriver, api % "compile->compile;test->test")
 
 lazy val driverTests213 = driverTests(scala213)
-  .usesIdeaPlugin(driverTestPlugin213)
+  .usesIdeaPlugins(driverTestPlugin213, driverTestPlugin212)
 
 lazy val probePlugin = ideaPluginModule("probe-plugin", "core/probePlugin", publish = true)
   .settings(intellijPluginName := "ideprobe")
@@ -170,7 +170,7 @@ lazy val scalaProbeDriver =
     .dependsOn(scalaProbeApi, driver)
 
 lazy val scalaProbeDriver213 = scalaProbeDriver(scala213)
-  .usesIdeaPlugin(scalaProbePlugin213)
+  .usesIdeaPlugins(scalaProbePlugin213, scalaProbePlugin212)
 
 lazy val scalaTests = testModule("scala-tests", "extensions/scala/tests").cross
   .dependsOn(junitDriver, robotDriver, scalaProbeDriver)
@@ -216,7 +216,7 @@ lazy val pantsProbeDriver =
     .dependsOn(pantsProbeApi, driver, robotDriver)
 
 lazy val pantsProbeDriver213 = pantsProbeDriver(scala213)
-  .usesIdeaPlugin(pantsProbePlugin213)
+  .usesIdeaPlugins(pantsProbePlugin213, pantsProbePlugin212)
 
 // bazel extension
 lazy val bazelProbeApi =
@@ -257,7 +257,7 @@ lazy val bazelProbeDriver =
     .dependsOn(bazelProbeApi, driver, robotDriver)
 
 lazy val bazelProbeDriver213 = bazelProbeDriver(scala213)
-  .usesIdeaPlugin(bazelProbePlugin213)
+  .usesIdeaPlugins(bazelProbePlugin213, bazelProbePlugin212)
 
 // examples
 lazy val examples = testModule("examples", "examples")
@@ -278,22 +278,22 @@ val commonSettings = Seq(
 
 // 2.12
 lazy val api212 = api(scala212)
-lazy val driver212 = driver(scala212).usesIdeaPlugin(probePlugin212)
+lazy val driver212 = driver(scala212).usesIdeaPlugins(probePlugin212, probePlugin213)
 lazy val robotDriver212 = robotDriver(scala212)
-lazy val driverTests212 = driverTests(scala212).usesIdeaPlugin(driverTestPlugin212)
+lazy val driverTests212 = driverTests(scala212).usesIdeaPlugins(driverTestPlugin212, driverTestPlugin213)
 lazy val probePlugin212 = probePlugin(scala212)
 lazy val driverTestPlugin212 = driverTestPlugin(scala212)
 lazy val junitDriver212 = junitDriver(scala212)
 lazy val scalaProbeApi212 = scalaProbeApi(scala212)
 lazy val scalaProbePlugin212 =
   scalaProbePlugin(scala212).settings(intellijPlugins += "org.intellij.scala:2020.2.49".toPlugin)
-lazy val scalaProbeDriver212 = scalaProbeDriver(scala212).usesIdeaPlugin(scalaProbePlugin212)
+lazy val scalaProbeDriver212 = scalaProbeDriver(scala212).usesIdeaPlugins(scalaProbePlugin212, scalaProbePlugin213)
 lazy val pantsProbeApi212 = pantsProbeApi(scala212)
 lazy val pantsProbePlugin212 = pantsProbePlugin(scala212)
-lazy val pantsProbeDriver212 = pantsProbeDriver(scala212).usesIdeaPlugin(pantsProbePlugin212)
+lazy val pantsProbeDriver212 = pantsProbeDriver(scala212).usesIdeaPlugins(pantsProbePlugin212, pantsProbePlugin213)
 lazy val bazelProbeApi212 = bazelProbeApi(scala212)
 lazy val bazelProbePlugin212 = bazelProbePlugin(scala212)
-lazy val bazelProbeDriver212 = bazelProbeDriver(scala212).usesIdeaPlugin(bazelProbePlugin212)
+lazy val bazelProbeDriver212 = bazelProbeDriver(scala212).usesIdeaPlugins(bazelProbePlugin212, bazelProbePlugin213)
 
 def project(id: String, path: String, publish: Boolean): Project = {
   Project(id, sbt.file(path))

--- a/ci/tests/2.12.10/test-probe
+++ b/ci/tests/2.12.10/test-probe
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export IDEPROBE_DISPLAY=xvfb
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+sbt "scala-tests/testOnly org.virtuslab.ideprobe.scala.BspImportTest"
+sbt "; clean; ++2.12.10! ; probe-test-plugin / test; junit-driver / test; driver / test; probe-plugin / test; api / test; driver-tests / test"

--- a/ci/tests/2.12.10/test-robot
+++ b/ci/tests/2.12.10/test-robot
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export IDEPROBE_DISPLAY=xvfb
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+
+sbt "; clean; ++2.12.10! ; robot-driver / test"

--- a/ci/tests/2.12.10/test-scala
+++ b/ci/tests/2.12.10/test-scala
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+export IDEPROBE_DISPLAY=xvfb
+export JAVA_HOME=/usr/local/openjdk-11
+
+sbt "; clean; ++2.12.10! ; scala-tests / test; scala-probe-plugin / test; scala-probe-driver / test; scala-probe-api / test"

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/IntelliJVersion.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/IntelliJVersion.scala
@@ -18,6 +18,9 @@ final case class IntelliJVersion(build: String, release: Option[String]) {
     }
   }
 
+  def compatibleScalaVersion: String =
+    if(inferredMajor.toDouble < 2020.3) "2.12" else "2.13"
+
   override def toString: String = {
     val version = release.fold(build)(r => s"$r, $build")
     s"IntelliJ($version)"

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/InternalPlugins.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/InternalPlugins.scala
@@ -1,11 +1,15 @@
 package org.virtuslab.ideprobe.dependencies
 
-import org.virtuslab.ideprobe.BuildInfo
+import org.virtuslab.ideprobe.{BuildInfo, IntelliJFixture}
 
 object InternalPlugins {
-  val probePlugin: Plugin = bundle("ideprobe")
 
-  val all = Seq(probePlugin)
+  def bundleCross(name: String, intelliJVersion: IntelliJVersion): Plugin =
+    Plugin.BundledCrossVersion(name, intelliJVersion.compatibleScalaVersion, BuildInfo.version)
 
-  def bundle(name: String): Plugin = Plugin.Bundled(s"$name-${BuildInfo.version}.zip")
+  def probePluginForIntelliJ(intelliJVersion: IntelliJVersion): Plugin = bundleCross("ideprobe", intelliJVersion)
+
+  def installCrossVersionPlugin(name: String): IntelliJFixture => IntelliJFixture = { fixture =>
+    fixture.withPlugin(bundleCross(name, fixture.version))
+  }
 }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Plugin.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Plugin.scala
@@ -15,6 +15,11 @@ object Plugin extends ConfigFormat {
       s"Plugin($bundle)"
     }
   }
+  case class BundledCrossVersion(bundle: String, scalaVersion: String, version: String) extends Plugin {
+    override def toString: String = {
+      s"Plugin(${bundle}_$scalaVersion-$version)"
+    }
+  }
 
   case class Versioned(id: String, version: String, channel: Option[String]) extends Plugin {
     override def toString: String = {
@@ -56,6 +61,7 @@ object Plugin extends ConfigFormat {
       deriveReader[Versioned],
       deriveReader[Direct],
       deriveReader[Bundled],
+      deriveReader[BundledCrossVersion],
       fromSourcesReader,
       deriveReader[Empty]
     )
@@ -66,6 +72,7 @@ object Plugin extends ConfigFormat {
       deriveWriter[Versioned],
       deriveWriter[Direct],
       deriveWriter[Bundled],
+      deriveWriter[BundledCrossVersion],
       fromSourcesWriter,
       deriveWriter[Empty]
     )

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJFactory.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJFactory.scala
@@ -21,7 +21,7 @@ final class IntelliJFactory(
   def create(version: IntelliJVersion, plugins: Seq[Plugin]): InstalledIntelliJ = {
     val root = createInstanceDirectory(version)
 
-    val allPlugins = InternalPlugins.all ++ plugins
+    val allPlugins = InternalPlugins.probePluginForIntelliJ(version) +: plugins
 
     installIntelliJ(version, root)
     installPlugins(allPlugins, root)

--- a/core/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
+++ b/core/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeDriverTest.scala
@@ -21,11 +21,12 @@ import scala.util.{Failure, Success, Try}
 
 @RunWith(classOf[JUnit4])
 final class ProbeDriverTest extends IdeProbeFixture with Assertions with RobotPluginExtension {
+  private val intellijVersion = IntelliJVersion.Latest
   private val scalaPlugin = Plugin("org.intellij.scala", "2020.3.553", Some("nightly"))
-  private val probeTestPlugin = ProbeTestPlugin.bundled
+  private val probeTestPlugin = ProbeTestPlugin.bundled(intellijVersion)
 
   private val fixture = IntelliJFixture(
-    version = IntelliJVersion.Latest,
+    version = intellijVersion,
     plugins = List(scalaPlugin, probeTestPlugin)
   ).enableExtensions
 

--- a/core/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeTestPlugin.scala
+++ b/core/driver/tests/src/test/scala/org/virtuslab/ideprobe/ProbeTestPlugin.scala
@@ -1,9 +1,10 @@
 package org.virtuslab.ideprobe
 
+import org.virtuslab.ideprobe.dependencies.IntelliJVersion
 import org.virtuslab.ideprobe.dependencies.InternalPlugins
 import org.virtuslab.ideprobe.dependencies.Plugin
 
 object ProbeTestPlugin {
   val id = "virtuslab.ideprobe.driver.test"
-  val bundled: Plugin = InternalPlugins.bundle("driver-test-plugin")
+  def bundled(version: IntelliJVersion): Plugin = InternalPlugins.bundleCross("driver-test-plugin", version)
 }

--- a/extensions/bazel/driver/src/main/scala/org/virtuslab/ideprobe/bazel/BazelPluginExtension.scala
+++ b/extensions/bazel/driver/src/main/scala/org/virtuslab/ideprobe/bazel/BazelPluginExtension.scala
@@ -1,8 +1,9 @@
 package org.virtuslab.ideprobe.bazel
 
-import org.virtuslab.ideprobe.dependencies.Plugin
 import org.virtuslab.ideprobe.robot.{RobotPluginExtension, RobotProbeDriver}
-import org.virtuslab.ideprobe.{BuildInfo, IdeProbeFixture, ProbeDriver, error}
+import org.virtuslab.ideprobe.{IdeProbeFixture, ProbeDriver, error}
+import org.virtuslab.ideprobe.dependencies.InternalPlugins
+
 import scala.language.implicitConversions
 
 trait BazelPluginExtension extends BazelOpenProjectFixture with RobotPluginExtension {
@@ -17,10 +18,7 @@ trait BazelPluginExtension extends BazelOpenProjectFixture with RobotPluginExten
       )
     }
   }
-
-  val bazelProbePlugin: Plugin = Plugin.Bundled(s"ideprobe-bazel-${BuildInfo.version}.zip")
-
-  registerFixtureTransformer(_.withPlugin(bazelProbePlugin))
+  registerFixtureTransformer(InternalPlugins.installCrossVersionPlugin("ideprobe-bazel"))
 
   registerFixtureTransformer(_.withAfterWorkspaceSetup { (intelliJ, ws) =>
     installBazelisk(bazelPath(ws), intelliJ.config)

--- a/extensions/pants/driver/src/main/scala/org/virtuslab/ideprobe/pants/PantsPluginExtension.scala
+++ b/extensions/pants/driver/src/main/scala/org/virtuslab/ideprobe/pants/PantsPluginExtension.scala
@@ -1,17 +1,17 @@
 package org.virtuslab.ideprobe.pants
 
-import org.virtuslab.ideprobe.dependencies.{DependencyProvider, Plugin}
+import org.virtuslab.ideprobe.dependencies.{DependencyProvider, InternalPlugins, Plugin}
 import org.virtuslab.ideprobe.robot.RobotPluginExtension
 import org.virtuslab.ideprobe.{BuildInfo, IdeProbeFixture, ProbeDriver}
+
 import scala.language.implicitConversions
 
 trait PantsPluginExtension extends PantsOpenProjectFixture with RobotPluginExtension {
   this: IdeProbeFixture =>
-  val pantsProbePlugin: Plugin = Plugin.Bundled(s"ideprobe-pants-${BuildInfo.version}.zip")
 
   DependencyProvider.registerBuilder(PantsPluginBuilder)
 
-  registerFixtureTransformer(_.withPlugin(pantsProbePlugin))
+  registerFixtureTransformer(InternalPlugins.installCrossVersionPlugin("ideprobe-pants"))
   registerFixtureTransformer(_.withAfterWorkspaceSetup(PantsSetup.overridePantsVersion))
 
   implicit def pantsProbeDriver(driver: ProbeDriver): PantsProbeDriver = PantsProbeDriver(driver)

--- a/extensions/scala/driver/src/main/scala/org/virtuslab/ideprobe/scala/ScalaPluginExtension.scala
+++ b/extensions/scala/driver/src/main/scala/org/virtuslab/ideprobe/scala/ScalaPluginExtension.scala
@@ -1,22 +1,18 @@
 package org.virtuslab.ideprobe.scala
 
 import org.virtuslab.ideprobe.Extensions._
-import org.virtuslab.ideprobe.IdeProbeFixture
-import org.virtuslab.ideprobe.ProbeDriver
+import org.virtuslab.ideprobe.{IdeProbeFixture, ProbeDriver}
 import org.virtuslab.ideprobe.dependencies.DependencyProvider
 import org.virtuslab.ideprobe.dependencies.InternalPlugins
-import org.virtuslab.ideprobe.dependencies.Plugin
 
 import scala.language.implicitConversions
 
 trait ScalaPluginExtension { this: IdeProbeFixture =>
   DependencyProvider.registerBuilder(ScalaPluginBuilder)
 
-  val scalaProbePlugin: Plugin = InternalPlugins.bundle("ideprobe-scala")
-
+  registerFixtureTransformer(InternalPlugins.installCrossVersionPlugin("ideprobe-scala"))
   registerFixtureTransformer { fixture =>
     fixture
-      .withPlugin(scalaProbePlugin)
       .withAfterIntelliJInstall { (_, inteliJ) =>
         // The scala-library from ideprobe plugin causes conflict with the scala-library from
         // scala plugin. This is why we delete one of them. We declare the scala-library as an

--- a/project/IdeaPluginAdapter.scala
+++ b/project/IdeaPluginAdapter.scala
@@ -1,10 +1,9 @@
 import org.jetbrains.sbtidea.SbtIdeaPlugin
-import org.jetbrains.sbtidea.packaging.PackagingKeys.packageArtifactZip
+import org.jetbrains.sbtidea.packaging.PackagingKeys.{packageArtifactZip, packageArtifactZipFile}
 import org.jetbrains.sbtidea.packaging.PackagingPlugin
 import org.jetbrains.sbtidea.tasks.structure.render.ProjectStructureVisualizerPlugin
-import sbt.Compile
+import sbt.{Compile, Project, file}
 import sbt.Keys.resourceGenerators
-import sbt.Project
 import sbt.internal.DslEntry
 
 object IdeaPluginAdapter {
@@ -16,6 +15,12 @@ object IdeaPluginAdapter {
       project
         .dependsOn(Project.classpathDependency(plugin))
         .settings(Compile / resourceGenerators += (plugin / packageArtifactZip).map(List(_)).taskValue)
+    }
+
+    def usesIdeaPlugins(basePlugin: Project, alternativeVersion: Project): Project = {
+      project
+        .usesIdeaPlugin(basePlugin)
+        .settings(Compile / resourceGenerators += (alternativeVersion / packageArtifactZip).map(List(_)).taskValue)
     }
 
     def enableIdeaPluginDevelopment: Project = {

--- a/project/IdeaPluginDevelopment.scala
+++ b/project/IdeaPluginDevelopment.scala
@@ -29,7 +29,7 @@ object IdeaPluginDevelopment extends AbstractSbtIdeaPlugin {
       .map(id => (id, Some(s"lib/${id.name}.jar"))),
     packageArtifactZipFilter := ((_: File) => true),
     packageOutputDir := crossTarget.value / "dist",
-    packageArtifactZipFile := crossTarget.value / s"${intellijPluginName.value}-${version.value}.zip",
+    packageArtifactZipFile := crossTarget.value / s"${intellijPluginName.value}_${scalaBinaryVersion.value}-${version.value}.zip",
     packageArtifactZip := Def.task {
       implicit val stream: TaskStreams = streams.value
       val distDir = packageArtifact.value


### PR DESCRIPTION
Adding both scala 2.12 and 2.13 plugins to drivers archives and enabling runtime pick based on IntelliJ version