### PR TITLE
Handle (un)trusted projects + refactoring

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,9 @@ val crossScalaVersions = List(scala212, scala213)
 skip in publish := true
 
 scalaVersion.in(ThisBuild) := scala213
-intellijBuild.in(ThisBuild) := "202.8194.7"
+intellijBuild.in(ThisBuild) := "2020.3.3"
 // provide intellij version in case of the release version
-val intellijVersion = None
+val intellijVersion: Option[String] = Some("203.7717.56")
 licenses.in(ThisBuild) := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 organization.in(ThisBuild) := "org.virtuslab.ideprobe"
 homepage.in(ThisBuild) := Some(url("https://github.com/VirtusLab/ide-probe"))
@@ -199,9 +199,9 @@ lazy val pantsProbePlugin =
       },
       name := "pants-probe-plugin",
       intellijPlugins ++= Seq(
-        "PythonCore".toPlugin,
-        "org.intellij.scala".toPlugin,
-        "com.intellij.plugins.pants:1.15.1.42d84c497b639ef81ebdae8328401e3966588b2c:bleedingedge".toPlugin
+        "PythonCore:203.7717.65".toPlugin,
+        "org.intellij.scala:2020.3.23".toPlugin,
+        "com.intellij.plugins.pants:1.17.0.7c71f505173a6499b6e0c91651e10ed03c6d2ff0:bleedingedge".toPlugin
       )
     )
     .cross
@@ -239,7 +239,7 @@ lazy val bazelProbePlugin =
       },
       name := "bazel-probe-plugin",
       intellijPlugins ++= Seq(
-        "com.google.idea.bazel.ijwb:2020.12.01.0.1".toPlugin
+        "com.google.idea.bazel.ijwb:2021.03.16.0.1:beta".toPlugin
       )
     )
     .cross

--- a/core/api/src/main/scala/org/virtuslab/ideprobe/protocol/Endpoints.scala
+++ b/core/api/src/main/scala/org/virtuslab/ideprobe/protocol/Endpoints.scala
@@ -29,11 +29,13 @@ object Endpoints {
   val Shutdown = Notification[Unit]("shutdown")
   val SyncFiles = Request[Unit, Unit]("fs/sync")
   val TakeScreenshot = Request[String, Unit]("screenshot")
-  val RunLocalInspection = Request[InspectionRunParams, InspectionRunResult]("inspections/local/run")
+  val RunLocalInspection =
+    Request[InspectionRunParams, InspectionRunResult]("inspections/local/run")
   val SetConfig = Request[String, Unit]("config/set")
   val BuildArtifact = Request[(ProjectRef, String), Unit]("buildArtifact")
-  val OpenFile = Request[(ProjectRef, Path), Unit]("fileOpen")
-  val GoToLineColumn = Request[(ProjectRef, Int, Int), Unit]("goToLineColumn")
+  val OpenEditor = Request[(ProjectRef, Path), Unit]("project/editors/open")
+  val GoToLineColumn = Request[(ProjectRef, Int, Int), Unit]("project/editors/current/goto")
+  val AddTrustedPath = Request[Path, Unit]("trustedPaths/add")
 
   // queries
   val FileReferences = Request[FileRef, Seq[Reference]]("file/references")
@@ -50,5 +52,5 @@ object Endpoints {
   val VcsRoots = Request[ProjectRef, Seq[VcsRoot]]("project/vcsRoots")
   val ExpandMacro = Request[ExpandMacroData, String](name = "expandMacro")
   val BackgroundTasks = Request[Unit, Seq[String]]("backgroundTasks")
-  val OpenFiles = Request[ProjectRef, Seq[String]]("project/openFiles")
+  val ListOpenEditors = Request[ProjectRef, Seq[Path]]("project/editors/all")
 }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/IdeProbePaths.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/IdeProbePaths.scala
@@ -3,7 +3,14 @@ package org.virtuslab.ideprobe
 import java.nio.file.{Path, Paths}
 import org.virtuslab.ideprobe.config.PathsConfig
 
-case class IdeProbePaths(base: Path, instances: Path, workspaces: Path, screenshots: Path, cache: Path)
+case class IdeProbePaths(
+    base: Path,
+    instances: Path,
+    workspaces: Path,
+    screenshots: Path,
+    cache: Path,
+    trusted: Path
+)
 
 object IdeProbePaths {
   val Default: IdeProbePaths = {
@@ -11,12 +18,14 @@ object IdeProbePaths {
   }
 
   def from(config: PathsConfig): IdeProbePaths = {
-    val basePath = config.base.getOrElse(Paths.get(System.getProperty("java.io.tmpdir")).resolve("ide-probe"))
+    val basePath =
+      config.base.getOrElse(Paths.get(System.getProperty("java.io.tmpdir")).resolve("ide-probe"))
     val instancesPath = config.instances.getOrElse(basePath.resolve("instances"))
     val workspacesPath = config.workspaces.getOrElse(basePath.resolve("workspaces"))
     val screenshotsPath = config.screenshots.getOrElse(basePath.resolve("screenshots"))
     val cachePath = config.cache.getOrElse(basePath.resolve("cache"))
+    val trustedPath = config.trusted.getOrElse(Paths.get("/"))
 
-    IdeProbePaths(basePath, instancesPath, workspacesPath, screenshotsPath, cachePath)
+    IdeProbePaths(basePath, instancesPath, workspacesPath, screenshotsPath, cachePath, trustedPath)
   }
 }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/config/PathsConfig.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/config/PathsConfig.scala
@@ -2,8 +2,11 @@ package org.virtuslab.ideprobe.config
 
 import java.nio.file.Path
 
-case class PathsConfig(base: Option[Path] = None,
-                       instances: Option[Path] = None,
-                       workspaces: Option[Path] = None,
-                       screenshots: Option[Path] = None,
-                       cache: Option[Path] = None)
+case class PathsConfig(
+    base: Option[Path] = None,
+    instances: Option[Path] = None,
+    workspaces: Option[Path] = None,
+    screenshots: Option[Path] = None,
+    cache: Option[Path] = None,
+    trusted: Option[Path] = None
+)

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/IntelliJVersion.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/IntelliJVersion.scala
@@ -17,13 +17,25 @@ final case class IntelliJVersion(build: String, release: Option[String]) {
       s"20$year.$version"
     }
   }
+
+  override def toString: String = {
+    val version = release.fold(build)(r => s"$r, $build")
+    s"IntelliJ($version)"
+  }
 }
 
 object IntelliJVersion {
   implicit val configConvert: ConfigConvert[IntelliJVersion] = deriveConvert[IntelliJVersion]
 
-  val Latest = IntelliJVersion.release("2020.3.2", "203.7148.57")
+  val Latest = BuildInfo.intellijVersion
+    .map(IntelliJVersion.release(BuildInfo.intellijBuild, _))
+    .getOrElse(IntelliJVersion.snapshot(BuildInfo.intellijBuild))
 
-  def snapshot(build: String): IntelliJVersion = IntelliJVersion(build, None)
-  def release(version: String, build: String): IntelliJVersion = IntelliJVersion(build, Some(version))
+  def snapshot(build: String): IntelliJVersion = {
+    IntelliJVersion(build, None)
+  }
+
+  def release(version: String, build: String): IntelliJVersion = {
+    IntelliJVersion(build, Some(version))
+  }
 }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Plugin.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Plugin.scala
@@ -9,13 +9,29 @@ import pureconfig.generic.semiauto.{deriveReader, deriveWriter}
 sealed trait Plugin
 
 object Plugin extends ConfigFormat {
-  case class Bundled(bundle: String) extends Plugin
-  case class Versioned(id: String, version: String, channel: Option[String]) extends Plugin
-  case class Direct(uri: URI) extends Plugin
+
+  case class Bundled(bundle: String) extends Plugin {
+    override def toString: String = {
+      s"Plugin($bundle)"
+    }
+  }
+
+  case class Versioned(id: String, version: String, channel: Option[String]) extends Plugin {
+    override def toString: String = {
+      s"Plugin($id:$version${channel.fold("")(":" + _)})"
+    }
+  }
+
+  case class Direct(uri: URI) extends Plugin {
+    override def toString: String = {
+      s"Plugin($uri)"
+    }
+  }
+
   case class FromSources(id: Id, config: Config) extends Plugin {
     override def toString: String = {
       val conf = config.source.value.fold(_.toString, _.render(ConfigRenderOptions.concise))
-      s"FromSources($id, $conf)"
+      s"Plugin($id, $conf)"
     }
   }
   private[ideprobe] case class Empty() extends Plugin

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
@@ -3,15 +3,13 @@ package org.virtuslab.ideprobe.ide.intellij
 import java.io.File
 import java.net.ServerSocket
 import java.nio.ByteBuffer
-import java.nio.file.Path
-
+import java.nio.file.{Path, Paths}
 import com.typesafe.config.ConfigRenderOptions
 import com.zaxxer.nuprocess.{NuAbstractProcessHandler, NuProcessBuilder}
 import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe._
 import org.virtuslab.ideprobe.config.DriverConfig
 import org.virtuslab.ideprobe.jsonrpc.JsonRpcConnection
-
 import scala.concurrent.{ExecutionContext, blocking}
 
 final class InstalledIntelliJ(val root: Path, probePaths: IdeProbePaths, config: DriverConfig) {
@@ -50,6 +48,7 @@ final class InstalledIntelliJ(val root: Path, probePaths: IdeProbePaths, config:
 
       val driver = ProbeDriver.start(connection, probeConfig)
       driver.setConfig(probeConfig)
+      driver.addTrustedPath(probePaths.trusted)
       new RunningIde(launcher, driver.pid(), driver)
     } catch {
       case cause: Exception =>
@@ -86,7 +85,8 @@ final class InstalledIntelliJ(val root: Path, probePaths: IdeProbePaths, config:
       }
 
       val overrideDisplay =
-        if (Display.Mode == Display.Xvfb) Map("DISPLAY" -> s":${Display.XvfbDisplayId}") else Map.empty
+        if (Display.Mode == Display.Xvfb) Map("DISPLAY" -> s":${Display.XvfbDisplayId}")
+        else Map.empty
       testCaseEnv ++ Map(
         "IDEA_VM_OPTIONS" -> vmoptions.toString,
         "IDEA_PROPERTIES" -> ideaProperties.toString,

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJFactory.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJFactory.scala
@@ -12,9 +12,11 @@ final class IntelliJFactory(
     val paths: IdeProbePaths,
     val config: DriverConfig
 ) {
-  def withConfig(config: DriverConfig): IntelliJFactory = new IntelliJFactory(dependencies, paths, config)
+  def withConfig(config: DriverConfig): IntelliJFactory =
+    new IntelliJFactory(dependencies, paths, config)
 
-  def withPaths(paths: IdeProbePaths): IntelliJFactory = new IntelliJFactory(dependencies, paths, config)
+  def withPaths(paths: IdeProbePaths): IntelliJFactory =
+    new IntelliJFactory(dependencies, paths, config)
 
   def create(version: IntelliJVersion, plugins: Seq[Plugin]): InstalledIntelliJ = {
     val root = createInstanceDirectory(version)
@@ -38,7 +40,6 @@ final class IntelliJFactory(
     val file = dependencies.fetch(version)
     toArchive(file).extractTo(root)
     root.resolve("bin/linux/fsnotifier64").makeExecutable()
-    println(s"Installed $version")
   }
 
   // This method differentiates plugins by their root entries in zip
@@ -84,7 +85,10 @@ object IntelliJFactory {
   val Default =
     new IntelliJFactory(
       new DependencyProvider(
-        new IntelliJDependencyProvider(Seq(IntelliJZipResolver.Community), ResourceProvider.Default),
+        new IntelliJDependencyProvider(
+          Seq(IntelliJZipResolver.Community),
+          ResourceProvider.Default
+        ),
         new PluginDependencyProvider(Seq(PluginResolver.Official), ResourceProvider.Default)
       ),
       IdeProbePaths.Default,
@@ -99,9 +103,12 @@ object IntelliJFactory {
     val intelliJResolver = IntelliJZipResolver.from(resolversConfig.intellij)
     val pluginResolver = PluginResolver.from(resolversConfig.plugins)
     val resourceProvider = ResourceProvider.from(paths)
-    val intelliJDependencyProvider = new IntelliJDependencyProvider(Seq(intelliJResolver), resourceProvider)
-    val pluginDependencyProvider = new PluginDependencyProvider(Seq(pluginResolver), resourceProvider)
-    val dependencyProvider = new DependencyProvider(intelliJDependencyProvider, pluginDependencyProvider)
+    val intelliJDependencyProvider =
+      new IntelliJDependencyProvider(Seq(intelliJResolver), resourceProvider)
+    val pluginDependencyProvider =
+      new PluginDependencyProvider(Seq(pluginResolver), resourceProvider)
+    val dependencyProvider =
+      new DependencyProvider(intelliJDependencyProvider, pluginDependencyProvider)
     new IntelliJFactory(dependencyProvider, paths, driverConfig)
   }
 }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/wait/DoOnlyOnce.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/wait/DoOnlyOnce.scala
@@ -18,6 +18,8 @@ package org.virtuslab.ideprobe.wait
 class DoOnlyOnce(action: => Unit) {
   private var doneSuccessfully = false
 
+  def isSuccessful: Boolean = doneSuccessfully
+
   def attempt(): Unit = {
     if (!doneSuccessfully) {
       try {
@@ -32,6 +34,8 @@ class DoOnlyOnce(action: => Unit) {
 
 class DoOnlyOnceLazyInit {
   private var doOnce: DoOnlyOnce = _
+
+  def isSuccessful: Boolean = doOnce.isSuccessful
 
   def attempt(action: => Unit): Unit = {
     if (doOnce == null) {

--- a/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/PathsConfigTest.scala
+++ b/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/PathsConfigTest.scala
@@ -10,18 +10,19 @@ import org.virtuslab.ideprobe.{Config, IdeProbePaths, IntelliJFixture}
 import scala.concurrent.ExecutionContext
 
 class PathsConfigTest {
-  private implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+  private implicit val ec: ExecutionContext =
+    ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
 
   @Test
   def usesProvidedPathsConfig(): Unit = {
-    val config = Config.fromString(
-      """
+    val config = Config.fromString("""
         |probe.paths {
         | base = "/base"
         | instances = "/instances"
         | workspaces = "/workspaces"
         | screenshots = "/screenshots"
         | cache = "/cache"
+        | trusted = "/trusted"
         |}
         |""".stripMargin)
     val fixture = IntelliJFixture.fromConfig(config)
@@ -31,7 +32,8 @@ class PathsConfigTest {
       Paths.get("/instances"),
       Paths.get("/workspaces"),
       Paths.get("/screenshots"),
-      Paths.get("/cache")
+      Paths.get("/cache"),
+      Paths.get("/trusted")
     )
 
     assertEquals(expected, fixture.probePaths)
@@ -39,8 +41,7 @@ class PathsConfigTest {
 
   @Test
   def usesProvidedBasePath(): Unit = {
-    val config = Config.fromString(
-      """
+    val config = Config.fromString("""
         |probe.paths {
         | base = "/base"
         |}
@@ -53,7 +54,8 @@ class PathsConfigTest {
       basePath.resolve("instances"),
       basePath.resolve("workspaces"),
       basePath.resolve("screenshots"),
-      basePath.resolve("cache")
+      basePath.resolve("cache"),
+      Paths.get("/")
     )
 
     assertEquals(expected, fixture.probePaths)
@@ -70,7 +72,8 @@ class PathsConfigTest {
       basePath.resolve("instances"),
       basePath.resolve("workspaces"),
       basePath.resolve("screenshots"),
-      basePath.resolve("cache")
+      basePath.resolve("cache"),
+      Paths.get("/")
     )
 
     assertEquals(expected, fixture.probePaths)

--- a/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/BaseProbeHandlerContributor.scala
+++ b/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/BaseProbeHandlerContributor.scala
@@ -45,8 +45,9 @@ class BaseProbeHandlerContributor extends ProbeHandlerContributor {
       .on(Endpoints.VcsRoots)(VCS.roots)
       .on(Endpoints.ExpandMacro)(ExpandMacro.expand)
       .on(Endpoints.BuildArtifact)((Builds.buildArtifact _).tupled)
-      .on(Endpoints.OpenFile)((Actions.openFile _).tupled)
-      .on(Endpoints.GoToLineColumn)((Actions.goToLineColumn _).tupled)
-      .on(Endpoints.OpenFiles)(Actions.openFiles)
+      .on(Endpoints.OpenEditor)((Editors.open _).tupled)
+      .on(Endpoints.GoToLineColumn)((Editors.goToLineColumn _).tupled)
+      .on(Endpoints.ListOpenEditors)(Editors.all)
+      .on(Endpoints.AddTrustedPath)(TrustedPaths.add)
   }
 }

--- a/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/Actions.scala
+++ b/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/Actions.scala
@@ -31,24 +31,4 @@ object Actions extends IntelliJApi {
     ActionManager.getInstance().tryToExecute(action, inputEvent, null, null, now)
   }
 
-  def openFile(projectRef: ProjectRef, file: Path): Unit =
-    runOnUISync {
-      val vFile = VirtualFileManager.getInstance().refreshAndFindFileByNioPath(file)
-      val project = resolve(projectRef)
-      new OpenFileDescriptor(project, vFile).navigate(true)
-    }
-
-  def goToLineColumn(projectRef: ProjectRef, line: Int, column: Int): Unit = {
-    runOnUISync {
-      val ed = FileEditorManager
-        .getInstance(resolve(projectRef))
-        .getSelectedTextEditor
-      val newPosition = new LogicalPosition(line, column)
-      ed.getCaretModel.moveToLogicalPosition(newPosition)
-    }
-  }
-
-  def openFiles(projectRef: ProjectRef): Seq[String] = runOnUISync {
-    FileEditorManager.getInstance(resolve(projectRef)).getOpenFiles.map(_.getPath)
-  }
 }

--- a/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/Editors.scala
+++ b/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/Editors.scala
@@ -1,0 +1,34 @@
+package org.virtuslab.ideprobe.handlers
+
+import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.fileEditor.{FileEditorManager, OpenFileDescriptor}
+import java.nio.file.{Path, Paths}
+import org.virtuslab.ideprobe.handlers.Projects.resolve
+import org.virtuslab.ideprobe.protocol.ProjectRef
+
+object Editors extends IntelliJApi {
+
+  def all(projectRef: ProjectRef): Seq[Path] = runOnUISync {
+    editorManager(projectRef).getOpenFiles.map(p => Paths.get(p.getPath))
+  }
+
+  def open(projectRef: ProjectRef, file: Path): Unit =
+    runOnUISync {
+      val vFile = VFS.toVirtualFile(file, refresh = true)
+      val project = resolve(projectRef)
+      new OpenFileDescriptor(project, vFile).navigate(true)
+    }
+
+  def goToLineColumn(projectRef: ProjectRef, line: Int, column: Int): Unit = {
+    runOnUISync {
+      val editor = editorManager(projectRef).getSelectedTextEditor
+      val newPosition = new LogicalPosition(line, column)
+      editor.getCaretModel.moveToLogicalPosition(newPosition)
+    }
+  }
+
+  private def editorManager(projectRef: ProjectRef) = {
+    FileEditorManager.getInstance(resolve(projectRef))
+  }
+
+}

--- a/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/Projects.scala
+++ b/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/Projects.scala
@@ -42,9 +42,12 @@ object Projects extends IntelliJApi {
 
   def importFromSources(path: Path, handleStep: PartialFunction[Any, Unit]): Unit = {
     val wizard = {
-      val providers = ProjectImportProvider.PROJECT_IMPORT_PROVIDER.getExtensions.filter(_.canCreateNewProject)
+      val providers =
+        ProjectImportProvider.PROJECT_IMPORT_PROVIDER.getExtensions.filter(_.canCreateNewProject)
       val wizard = runOnUISync(
-        write(ImportModuleAction.createImportWizard(null, null, VFS.toVirtualFile(path), providers: _*))
+        write(
+          ImportModuleAction.createImportWizard(null, null, VFS.toVirtualFile(path), providers: _*)
+        )
       )
 
       @tailrec def goThroughWizard(): Unit = {

--- a/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/TrustedPaths.scala
+++ b/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/TrustedPaths.scala
@@ -1,0 +1,18 @@
+package org.virtuslab.ideprobe.handlers
+
+import com.intellij.openapi.components.ServiceManager
+import java.nio.file.Path
+import org.virtuslab.ideprobe.handlers.App.ReflectionOps
+
+object TrustedPaths {
+  def add(path: Path): Unit = {
+    try {
+      val className = Class.forName("com.intellij.ide.impl.TrustedPathsSettings")
+      val settings = ServiceManager.getService(className)
+      settings.invoke[Unit]("addTrustedPath")(path.toString)
+    } catch {
+      case _: ClassNotFoundException =>
+        println("Trusted paths not supported in this version of IntelliJ")
+    }
+  }
+}

--- a/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/VFS.scala
+++ b/core/probePlugin/src/main/scala/org/virtuslab/ideprobe/handlers/VFS.scala
@@ -29,8 +29,12 @@ object VFS extends IntelliJApi {
     }
   }
 
-  def toVirtualFile(path: Path): VirtualFile = {
-    LocalFileSystem.getInstance.findFileByPath(path.toString)
+  def toVirtualFile(path: Path, refresh: Boolean = false): VirtualFile = {
+    if (refresh) {
+      LocalFileSystem.getInstance.refreshAndFindFileByNioFile(path)
+    } else {
+      LocalFileSystem.getInstance.findFileByNioFile(path)
+    }
   }
 
   def toPath(virtualFile: VirtualFile): Path = {

--- a/extensions/pants/driver/src/main/scala/org/virtuslab/ideprobe/pants/PantsProbeDriver.scala
+++ b/extensions/pants/driver/src/main/scala/org/virtuslab/ideprobe/pants/PantsProbeDriver.scala
@@ -48,7 +48,9 @@ final class PantsProbeDriver(val driver: ProbeDriver) extends AnyVal {
   }
 
   def compileAllTargets(timeout: Duration = 10.minutes): PantsBuildResult = {
-    driver.invokeActionAsync("com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsAction")
+    driver.invokeActionAsync(
+      "com.twitter.intellij.pants.compiler.actions.PantsCompileAllTargetsAction"
+    )
     val compiledNotification = Try(driver.awaitNotification("Compile message", timeout))
     val robot = RobotProbeDriver(driver).robot
 

--- a/extensions/robot/driver/src/main/scala/org/virtuslab/ideprobe/robot/RobotProbeDriver.scala
+++ b/extensions/robot/driver/src/main/scala/org/virtuslab/ideprobe/robot/RobotProbeDriver.scala
@@ -58,7 +58,10 @@ final class RobotProbeDriver(
     }
   }
 
-  def openProject(path: Path, waitLogic: WaitLogic = WaitLogic.Default): ProjectRef = {
+  def openProject(
+      path: Path,
+      waitLogic: WaitLogic = WaitLogic.Default
+  ): ProjectRef = {
     driver.openProject(path, extendWaitLogic(waitLogic))
   }
 


### PR DESCRIPTION
Add default trusted path to IdeProbePaths and set this path as trusted on startup. By default it is "/"
Factor out Editor related code from Actions
Add sendAsync to ProbeDriver
Allow for doWhileWaiting { driver => ... } (get hold of driver)
Improve toString of IntelliJVersion and Plugin as they show on each probe startup
Update IntelliJ and plugin versions
Set back IntelliJVersion.Latest to point to version from build
DoOnlyOnce.isSuccessful added
