### PR TITLE
Special logger for JsonRpcEndpoint

### DIFF
--- a/core/api/src/main/scala/org/virtuslab/ideprobe/jsonrpc/JsonRpcEndpoint.scala
+++ b/core/api/src/main/scala/org/virtuslab/ideprobe/jsonrpc/JsonRpcEndpoint.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 import scala.reflect.ClassTag
 
 trait JsonRpcEndpoint extends AutoCloseable {
-  private val logger: RequestResponseLogger = new RequestResponseLogger
+  private val logger = new RequestResponseLogger
   protected def connection: JsonRpcConnection
 
   implicit protected def ec: ExecutionContext

--- a/core/api/src/main/scala/org/virtuslab/ideprobe/jsonrpc/logging/RequestResponseLogger.scala
+++ b/core/api/src/main/scala/org/virtuslab/ideprobe/jsonrpc/logging/RequestResponseLogger.scala
@@ -59,7 +59,7 @@ class RequestResponseLogger {
           println(request)
           println(response)
         case (RequestAndResponse(request, response), count) =>
-          println(s"""Repeated $count times over ${java.time.temporal.ChronoUnit.SECONDS.between(firstMessageTimestamp, now)} seconds: {
+          println(s"""Repeated $count times ${formatSeconds(java.time.temporal.ChronoUnit.SECONDS.between(firstMessageTimestamp, now))}: {
                      |  $request
                      |  $response
                      |}""".stripMargin)
@@ -70,6 +70,12 @@ class RequestResponseLogger {
       }
       buffer = Nil
     } else ()
+  }
+
+  private def formatSeconds(secondsPassed: Long): String = secondsPassed match {
+    case 0L => "in less than one second"
+    case 1L => "over one second"
+    case n => s"over $n seconds"
   }
 
   private def collectCountingSubsequent[A](xs: List[A]): List[(A, Int)] = {

--- a/core/api/src/main/scala/org/virtuslab/ideprobe/jsonrpc/logging/RequestResponseLogger.scala
+++ b/core/api/src/main/scala/org/virtuslab/ideprobe/jsonrpc/logging/RequestResponseLogger.scala
@@ -1,0 +1,76 @@
+package org.virtuslab.ideprobe.jsonrpc.logging
+
+import java.time.ZonedDateTime
+import java.util.concurrent.{ScheduledFuture, ScheduledThreadPoolExecutor, TimeUnit}
+
+class RequestResponseLogger {
+
+  private val ex = new ScheduledThreadPoolExecutor(1)
+  private val ticker: Runnable = () => flush()
+  private var task: Option[ScheduledFuture[_]] = None
+
+  private sealed trait LogEntry
+  private case class Request(message: String) extends LogEntry
+  private case class Response(message: String) extends LogEntry
+  private case class RequestAndResponse(request: String, response: String) extends LogEntry
+
+  private var buffer: List[(LogEntry, ZonedDateTime)] = List.empty
+
+  def logRequest(request: String): Unit = buffer.synchronized {
+    task.foreach(_.cancel(true))
+    buffer match {
+      case (head @ (RequestAndResponse(`request`, _), _)) :: tail =>
+        buffer = (Request(request), ZonedDateTime.now()) :: head :: tail
+      case _ =>
+        flush()
+        buffer = (Request(request), ZonedDateTime.now()) :: Nil
+    }
+    task = Option(ex.schedule(ticker, 1, TimeUnit.SECONDS))
+  }
+
+  def logResponse(response: String): Unit = buffer.synchronized {
+    task.foreach(_.cancel(true))
+    buffer match {
+      case (Request(request), timestamp) :: Nil =>
+        buffer = (RequestAndResponse(request, response), timestamp) :: Nil
+      case (Request(ultimate), timestamp) :: (penultimate @ (RequestAndResponse(_, `response`), _)) :: tail =>
+        buffer = (RequestAndResponse(ultimate, response), timestamp) :: penultimate :: tail
+      case (Request(request), timestamp) :: tail =>
+        buffer = tail
+        flush()
+        buffer = (RequestAndResponse(request, response), timestamp) :: Nil
+      case _ =>
+        buffer = (Response(response), ZonedDateTime.now()) :: buffer
+        flush()
+    }
+    task = Option(ex.schedule(ticker, 1, TimeUnit.SECONDS))
+  }
+
+  private def flush(): Unit = buffer.synchronized {
+    val now = ZonedDateTime.now()
+    val firstMessageTimestamp = buffer.reverse.headOption.map(_._2).getOrElse(now)
+    collectCountingSubsequent(buffer.map(_._1).reverse).foreach {
+      case (RequestAndResponse(request, response), 1) =>
+        println(request)
+        println(response)
+      case (RequestAndResponse(request, response), count) =>
+        println(s"""Repeated $count times over ${java.time.temporal.ChronoUnit.SECONDS.between(firstMessageTimestamp, now)} seconds: {
+                 |  $request
+                 |  $response
+                 |}""".stripMargin)
+      case (Request(request), _) => //Here and below the count will always be 1 - see the buffering mechanism.
+        println(request)
+      case (Response(response), _) =>
+        println(response)
+    }
+    buffer = Nil
+  }
+
+  private def collectCountingSubsequent[X](xs: List[X]): List[(X, Int)] =
+    xs.foldLeft(List.empty[(X, Int)]) { (acc, elem) =>
+      (acc.reverse match {
+        case (`elem`, count) :: tail => (elem, count + 1) :: tail
+        case other => (elem, 1) :: other
+      }).reverse
+    }
+}

--- a/core/api/src/test/scala/org/virtuslab/ideprobe/jsonrpc/logging/RequestResponseLoggerTest.scala
+++ b/core/api/src/test/scala/org/virtuslab/ideprobe/jsonrpc/logging/RequestResponseLoggerTest.scala
@@ -1,0 +1,139 @@
+package org.virtuslab.ideprobe.jsonrpc.logging
+
+import org.junit.{Assert, Test}
+
+import java.io.ByteArrayOutputStream
+
+class RequestResponseLoggerTest {
+  private val request = "request"
+  private val response = "response"
+  private val differentRequest = "different request"
+  private val differentResponse = "different response"
+
+  @Test
+  def firstDifferentRequestShouldCauseTheBufferToBePrinted(): Unit = withStdout { stdout =>
+    val logger = new RequestResponseLogger
+    logger.logRequest(request)
+    logger.logResponse(response)
+    logger.logRequest(request)
+    logger.logResponse(response)
+    logger.logRequest(differentRequest)
+    Assert.assertEquals(
+      s"""Repeated 2 times over 0 seconds: {
+        |  $request
+        |  $response
+        |}
+        |""".stripMargin,
+      stdout.toString
+    )
+  }
+
+  @Test
+  def firstDifferentResponseShouldCauseTheBufferToBePrinted(): Unit = withStdout { stdout =>
+    val logger = new RequestResponseLogger
+
+    logger.logRequest(request)
+    logger.logResponse(response)
+    logger.logRequest(request)
+    logger.logResponse(response)
+    logger.logRequest(request)
+    logger.logResponse(differentResponse)
+
+    Assert.assertEquals(
+      s"""Repeated 2 times over 0 seconds: {
+         |  $request
+         |  $response
+         |}
+         |""".stripMargin,
+      stdout.toString
+    )
+  }
+
+  @Test
+  def responseWithoutPrecedingRequestShouldBePrintedImmediately(): Unit = withStdout { stdout =>
+    val logger = new RequestResponseLogger
+
+    logger.logResponse(response)
+
+    Assert.assertEquals(
+      s"$response\n",
+      stdout.toString
+    )
+  }
+
+  @Test
+  def twoDifferentRequestsWithoutResponseInBetweenShouldCauseTheFirstRequestToBePrinted(): Unit = withStdout { stdout =>
+    val logger = new RequestResponseLogger
+
+    logger.logRequest(request)
+    logger.logRequest(differentRequest)
+
+    Assert.assertEquals(
+      s"$request\n",
+      stdout.toString
+    )
+  }
+
+  @Test
+  def twoRepeatedRequestsWithoutResponseInBetweenShouldCauseTheFirstRequestToBePrinted(): Unit = withStdout { stdout =>
+    val logger = new RequestResponseLogger
+    logger.logRequest(request)
+    logger.logRequest(request)
+
+    Assert.assertEquals(
+      s"$request\n",
+      stdout.toString
+    )
+  }
+
+  @Test
+  def messagesShouldBePrintedAfterSpecifiedAmountOfTimePasses(): Unit = withStdout { stdout =>
+    val logger = new RequestResponseLogger
+    logger.logRequest(request)
+    logger.logResponse(response)
+    logger.logRequest(request)
+    logger.logResponse(response)
+    Thread.sleep(1200L)
+
+    Assert.assertEquals(
+      s"""Repeated 2 times over 1 seconds: {
+                   |  $request
+                   |  $response
+                   |}
+                   |""".stripMargin,
+      stdout.toString
+    )
+  }
+
+  @Test
+  def loggingNewRequestShouldResetTheTimer(): Unit = withStdout { stdout =>
+    val logger = new RequestResponseLogger
+
+    logger.logRequest(request)
+    Thread.sleep(500L)
+    logger.logResponse(response)
+    Thread.sleep(500L)
+    logger.logRequest(request)
+    Thread.sleep(500L)
+    logger.logResponse(response)
+    Thread.sleep(500L)
+    logger.logRequest(request)
+    Thread.sleep(500L)
+    logger.logResponse(response)
+    Thread.sleep(1200L)
+
+    Assert.assertEquals(
+      s"""Repeated 3 times over 3 seconds: {
+         |  $request
+         |  $response
+         |}
+         |""".stripMargin,
+      stdout.toString
+    )
+  }
+
+  def withStdout(test: ByteArrayOutputStream => Unit): Unit = {
+    val output = new ByteArrayOutputStream
+    Console.withOut(output)(test(output))
+  }
+}

--- a/core/api/src/test/scala/org/virtuslab/ideprobe/jsonrpc/logging/RequestResponseLoggerTest.scala
+++ b/core/api/src/test/scala/org/virtuslab/ideprobe/jsonrpc/logging/RequestResponseLoggerTest.scala
@@ -19,7 +19,7 @@ class RequestResponseLoggerTest {
     logger.logResponse(response)
     logger.logRequest(differentRequest)
     Assert.assertEquals(
-      s"""Repeated 2 times over 0 seconds: {
+      s"""Repeated 2 times in less than one second: {
         |  $request
         |  $response
         |}
@@ -40,7 +40,7 @@ class RequestResponseLoggerTest {
     logger.logResponse(differentResponse)
 
     Assert.assertEquals(
-      s"""Repeated 2 times over 0 seconds: {
+      s"""Repeated 2 times in less than one second: {
          |  $request
          |  $response
          |}
@@ -96,7 +96,7 @@ class RequestResponseLoggerTest {
     Thread.sleep(1200L)
 
     Assert.assertEquals(
-      s"""Repeated 2 times over 1 seconds: {
+      s"""Repeated 2 times over one second: {
                    |  $request
                    |  $response
                    |}


### PR DESCRIPTION
A RequestResponseLogger capable of buffering and counting repeated requests and
responses was created and plugged into JsonRpcEndpoint to reduce noise
in the logs.

Fixes #121