### PR TITLE
Keep bazel viewconfig file through lifetime of the project

### DIFF
--- a/extensions/bazel/driver/src/main/scala/org/virtuslab/ideprobe/bazel/BazelProbeDriver.scala
+++ b/extensions/bazel/driver/src/main/scala/org/virtuslab/ideprobe/bazel/BazelProbeDriver.scala
@@ -101,8 +101,6 @@ class BazelProbeDriver(val driver: ProbeDriver) {
 
     driver.await(waitLogic)
 
-    projectView.delete()
-
     driver.listOpenProjects().head
   }
 
@@ -113,8 +111,10 @@ class BazelProbeDriver(val driver: ProbeDriver) {
          |derive_targets_from_directories: true
          |
          |${section("additional_languages", importSpec.languages)}""".stripMargin
-    val file = workspace.resolve(s"ide-probe${UUID.randomUUID()}.viewconfig")
+    val dir = workspace.resolve(".ide-probe-bazel-projects").createDirectory()
+    val file = dir.resolve(s"ide-probe${UUID.randomUUID()}.viewconfig")
     file.write(text)
+    file.toFile.deleteOnExit()
     workspace.relativize(file)
   }
 


### PR DESCRIPTION
This file is used by bazel plugin, for example when invoking project sync or running tests. If we want to use the plugin properly, we can't delete that.
Additionally I moved these files into a hidden subdirectory, to be less messy in the workspace.