### PR TITLE
Add support for unzipped IntelliJs in resolvers.intellij.repositories config

### DIFF
--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Dependency.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Dependency.scala
@@ -7,6 +7,7 @@ sealed trait Dependency
 object Dependency {
   case class Artifact(uri: URI) extends Dependency
   case class Sources(id: Id, config: Config) extends Dependency
+  case object Missing extends Dependency
 
   def apply(path: String): Dependency = Artifact(URI.create(path))
 }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/JbrResolvers.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/JbrResolvers.scala
@@ -29,7 +29,7 @@ case class JbrPatternResolver(pattern: String) extends DependencyResolver[Path] 
 
   override def resolve(path: Path): Dependency = {
     extractVersionFromInstalledIntelliJ(path) match {
-      case Some((minor, major)) =>
+      case Some((major, minor)) =>
         val platform = OS.Current match {
           case OS.Windows => "windows"
           case OS.Unix => "linux"

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Resource.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Resource.scala
@@ -53,15 +53,26 @@ object Resource extends ConfigFormat {
   case class Http(uri: URI) extends Resource
   case class Unresolved(path: String, cause: Throwable) extends Resource
 
-  final class Archive(path: Path) {
-    def extractTo(target: Path): Unit = {
-      val zip = new ZipInputStream(path.inputStream)
-      zip.unpackTo(target)
-    }
+  sealed trait IntellijResource {
+    def path: Path
+    def installTo(target: Path): Unit
 
     def rootEntries: List[String] = {
       val fs = FileSystems.newFileSystem(path, this.getClass.getClassLoader)
       Files.list(fs.getPath("/")).iterator.asScala.map(_.toString).toList
+    }
+  }
+
+  final class Archive(val path: Path) extends IntellijResource {
+    def installTo(target: Path): Unit = {
+      val zip = new ZipInputStream(path.inputStream)
+      zip.unpackTo(target)
+    }
+  }
+
+  final class Plain(val path: Path) extends  IntellijResource {
+    def installTo(target: Path): Unit = {
+      path.copyDir(target)
     }
   }
 
@@ -84,9 +95,16 @@ object Resource extends ConfigFormat {
     }
   }
 
-  implicit class ArchiveExtension(path: Path) {
-    def toArchive: Archive = path match {
+  object Plain {
+    def unapply(path: Path): Option[Plain] = {
+      if(path.isDirectory) Some(new Plain(path)) else None
+    }
+  }
+
+  implicit class ExtractorExtension(path: Path) {
+    def toExtracted: IntellijResource = path match {
       case Archive(archive) => archive
+      case Plain(archive) => archive
       case _                => throw new IllegalStateException(s"Not an archive: $path")
     }
   }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
@@ -69,7 +69,7 @@ sealed abstract class InstalledIntelliJ(root: Path, probePaths: IdeProbePaths, c
     val content = {
       val macOsLauncher = paths.root.resolve("MacOS").resolve("idea")
       val launcher =
-        if(macOsLauncher.toFile.exists())
+        if(OS.Current == OS.Mac && macOsLauncher.toFile.exists())
           macOsLauncher
         else
           paths.bin.resolve("idea.sh")

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
@@ -67,11 +67,13 @@ sealed abstract class InstalledIntelliJ(root: Path, probePaths: IdeProbePaths, c
 
   private val executable: Path = {
     val content = {
-      val launcher = if (OS.Current == OS.Mac) {
-        paths.root.resolve("MacOS").resolve("idea")
-      } else {
-        paths.bin.resolve("idea.sh")
-      }
+      val macOsLauncher = paths.root.resolve("MacOS").resolve("idea")
+      val launcher =
+        if(macOsLauncher.toFile.exists())
+          macOsLauncher
+        else
+          paths.bin.resolve("idea.sh")
+
       launcher.makeExecutable()
 
       val command =

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
@@ -144,6 +144,7 @@ final case class IntelliJFactory(
   }
 
   private def installIntelliJ(version: IntelliJVersion, root: Path): Unit = {
+    println(s"Installing $version")
     val fileOpt = dependencies.intelliJ.fetch(version)
     fileOpt match {
       case Some(file) =>

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
@@ -36,8 +36,12 @@ sealed trait IntelliJProvider {
 
     val targetDir = intelliJ.paths.bundledPlugins
     val archives = withParallel[Plugin, PluginArchive](allPlugins)(_.map { plugin =>
-      val file = dependencies.plugin.fetch(plugin)
-      PluginArchive(plugin, file.toExtracted)
+      val fileOpt = dependencies.plugin.fetch(plugin)
+      fileOpt match {
+        case Some(file) => PluginArchive(plugin, file.toExtracted)
+        case _ => error("Plugin archive not found")
+
+      }
     })
 
     val distinctPlugins = archives.reverse.distinctBy(_.rootEntries).reverse
@@ -140,10 +144,13 @@ final case class IntelliJFactory(
   }
 
   private def installIntelliJ(version: IntelliJVersion, root: Path): Unit = {
-    println(s"Installing $version")
-    val file = dependencies.intelliJ.fetch(version)
-    file.toExtracted.installTo(root)
-    root.resolve("bin").makeExecutableRecursively()
+    val fileOpt = dependencies.intelliJ.fetch(version)
+    fileOpt match {
+      case Some(file) =>
+        file.toExtracted.installTo(root)
+        root.resolve("bin").makeExecutableRecursively()
+      case None => error("Intellij artifacts not found")
+    }
   }
 }
 

--- a/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/IntelliJProviderTest.scala
+++ b/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/IntelliJProviderTest.scala
@@ -65,12 +65,9 @@ final class IntelliJProviderTest {
                                       |}
                                       |""".stripMargin)
 
-    val fixture = IntelliJFixture.fromConfig(config).headless
+    val fixture = IntelliJFixture.fromConfig(config)
 
     val existingInstalledIntelliJ = fixture.installIntelliJ()
-    val ide = existingInstalledIntelliJ.startIn(IdeProbePaths.Default.workspaces, config)
-    ide.probe.await()
-    ide.probe.shutdown()
 
     //when
     existingInstalledIntelliJ.cleanup()

--- a/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/IntelliJProviderTest.scala
+++ b/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/IntelliJProviderTest.scala
@@ -52,6 +52,29 @@ final class IntelliJProviderTest {
     )
   }
 
+
+  @Test
+  def shouldInstallIntellijFromExtractedRepository: Unit = givenInstalledIntelliJ { installationRoot =>
+
+    val build = IntelliJVersion.Latest.build
+    val installationPattern = installationRoot.toString.replace(build, "[revision]")
+    val config = Config.fromString(s"""
+                                      |probe.intellij {
+                                      |    repositories = [\"$installationPattern\"]
+                                      |}
+                                      |""".stripMargin)
+
+    val fixture = IntelliJFixture.fromConfig(config)
+
+    val existingInstalledIntelliJ = fixture.installIntelliJ()
+
+    //when
+    existingInstalledIntelliJ.cleanup()
+
+    //then
+    assert(!existingInstalledIntelliJ.paths.root.isDirectory, "The provided IntelliJ instance should not exist after cleanup, but it was deleted.")
+  }
+
   @Test
   def existingIntelliJShouldRetainItsOriginalPluginsDuringCleanup: Unit = givenInstalledIntelliJ { installationRoot =>
     //given a pre-installed IntelliJ and an IntelliJProvider


### PR DESCRIPTION
Automatically recognise if it is a zip archive or directory.

Closes: #158 