### PR TITLE
Fix installing bundled plugins (file downloader rollback) and awkward apis

### DIFF
--- a/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/BenchmarkSuite.scala
+++ b/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/BenchmarkSuite.scala
@@ -3,7 +3,7 @@ package org.virtuslab.ideprobe.benchmark
 import org.virtuslab.ideprobe.benchmark.report.BenchmarkReporter
 
 case class BenchmarkSuite[A](name: String, benchmarks: Seq[BaseBenchmark[A]]) {
-  def run(reporter: BenchmarkReporter): Unit = {
+  def run(reporter: BenchmarkReporter[A]): Unit = {
     println(s"Running benchmark suite: $name")
     val results = benchmarks.flatMap(_.runOpt())
     reporter.report(name, results)

--- a/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/report/BenchmarkReporter.scala
+++ b/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/report/BenchmarkReporter.scala
@@ -1,6 +1,6 @@
 package org.virtuslab.ideprobe.benchmark
 package report
 
-trait BenchmarkReporter {
-  def report[A](name: String, results: Seq[BenchmarkResult[A]]): Unit
+trait BenchmarkReporter[A] {
+  def report(name: String, results: Seq[BenchmarkResult[A]]): Unit
 }

--- a/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/report/CSVBenchmarkReporter.scala
+++ b/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/report/CSVBenchmarkReporter.scala
@@ -7,9 +7,9 @@ import java.nio.file.StandardOpenOption
 
 import scala.concurrent.duration._
 
-class CSVBenchmarkReporter extends BenchmarkReporter {
+class CSVBenchmarkReporter[A] extends BenchmarkReporter[A] {
 
-  def report[A](suite: String, results: Seq[BenchmarkResult[A]]): Unit = {
+  def report(suite: String, results: Seq[BenchmarkResult[A]]): Unit = {
     val output = Paths.get(s"$suite.csv")
 
     val headers = Seq(

--- a/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/report/CompositeBenchmarkReporter.scala
+++ b/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/report/CompositeBenchmarkReporter.scala
@@ -1,8 +1,8 @@
 package org.virtuslab.ideprobe.benchmark
 package report
 
-class CompositeBenchmarkReporter(reporters: Seq[BenchmarkReporter]) extends BenchmarkReporter {
-  override def report[A](suite: String, results: Seq[BenchmarkResult[A]]): Unit = {
+class CompositeBenchmarkReporter[A](reporters: Seq[BenchmarkReporter[A]]) extends BenchmarkReporter[A] {
+  override def report(suite: String, results: Seq[BenchmarkResult[A]]): Unit = {
     reporters.foreach(_.report(suite, results))
   }
 }

--- a/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/report/ConsoleBenchmarkReporter.scala
+++ b/benchmarks/src/main/scala/org/virtuslab/ideprobe/benchmark/report/ConsoleBenchmarkReporter.scala
@@ -3,8 +3,8 @@ package report
 
 import scala.concurrent.duration._
 
-class ConsoleBenchmarkReporter extends BenchmarkReporter {
-  def report[A](suite: String, results: Seq[BenchmarkResult[A]]): Unit = {
+class ConsoleBenchmarkReporter[A] extends BenchmarkReporter[A] {
+  def report(suite: String, results: Seq[BenchmarkResult[A]]): Unit = {
     def toSeconds(time: Duration): String = (time.toMillis / 1e3).toString
     def toSecondsOpt(time: Option[Duration]): String = time.fold("None")(toSeconds)
 

--- a/benchmarks/src/test/scala/org/virtuslab/ideprobe/benchmark/BenchmarkSuiteTest.scala
+++ b/benchmarks/src/test/scala/org/virtuslab/ideprobe/benchmark/BenchmarkSuiteTest.scala
@@ -24,9 +24,9 @@ final class BenchmarkSuiteTest {
   def simpleBenchmarkWithCustomData(): Unit = {
 
     val result = "test result"
-    val benchmarks = List(new TestBenchmark("test", result))
-    BenchmarkSuite("open-project", benchmarks).run(new BenchmarkReporter {
-      override def report[B](name: String, results: Seq[BenchmarkResult[B]]): Unit = {
+    val benchmarks = List(new TestBenchmark[String]("test", result))
+    BenchmarkSuite("open-project", benchmarks).run(new BenchmarkReporter[String] {
+      override def report(name: String, results: Seq[BenchmarkResult[String]]): Unit = {
         assertEquals(Seq(result), results.head.customData)
       }
     })
@@ -35,9 +35,9 @@ final class BenchmarkSuiteTest {
   @Test
   def simpleBenchmarkWithoutCustomData(): Unit = {
 
-    val benchmarks = List(new TestBenchmark("test", ()))
-    BenchmarkSuite("open-project", benchmarks).run(new BenchmarkReporter {
-      override def report[B](name: String, results: Seq[BenchmarkResult[B]]): Unit = {
+    val benchmarks = List(new TestBenchmark[Unit]("test", ()))
+    BenchmarkSuite("open-project", benchmarks).run(new BenchmarkReporter[Unit]() {
+      override def report(name: String, results: Seq[BenchmarkResult[Unit]]): Unit = {
         assertEquals(Seq.empty, results.head.customData)
       }
     })

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/DependencyProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/DependencyProvider.scala
@@ -64,14 +64,18 @@ abstract class BaseDependencyProvider[A](
 ) {
 
   def fetchOpt(key: A): Option[Path] = {
-    if (resolvers.isEmpty) None else fetch(key)
+    val noResolvers = Option.empty[Path]
+    resolvers
+      .foldLeft(noResolvers) { (result, resolver) =>
+        result.orElse(Try(resolve(key, resolver)).toOption.flatten)
+      }
   }
 
-  def fetch(key: A): Option[Path] = {
-    val noResolversError = Try[Option[Path]](error("Dependency resolver list is empty"))
+  def fetch(key: A): Path = {
+    val noResolversError = Try[Path](error("Dependency resolver list is empty"))
     resolvers
       .foldLeft(noResolversError) { (result, resolver) =>
-        result.orElse(Try(resolve(key, resolver)))
+        result.orElse(Try(resolve(key, resolver).get))
       }
       .get
   }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/ResourceProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/ResourceProvider.scala
@@ -9,7 +9,6 @@ import scala.annotation.tailrec
 
 import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe.IdeProbePaths
-import org.virtuslab.ideprobe.download.FileDownloader
 
 trait ResourceProvider {
   def get(uri: URI, provider: () => InputStream): Path
@@ -62,10 +61,12 @@ object ResourceProvider {
       val cachedResource = cached(uri)
       if (!cachedResource.isFile) {
         retry(retries) { () =>
+          val stream = createStream()
           println(message(cachedResource))
-          val tempFile: Path = Files.createTempDirectory("cached-resource")
-          val downloader = FileDownloader(tempFile).download(uri.toURL)
-          downloader.moveTo(cachedResource)
+          Files
+            .createTempFile("cached-resource", "-tmp")
+            .append(stream)
+            .moveTo(cachedResource)
         }
       }
       cachedResource

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
@@ -41,12 +41,8 @@ sealed trait IntelliJProvider {
 
     val targetDir = intelliJ.paths.bundledPlugins
     val archives = withParallel[Plugin, PluginArchive](allPlugins)(_.map { plugin =>
-      val fileOpt = dependencies.plugin.fetch(plugin)
-      fileOpt match {
-        case Some(file) => PluginArchive(plugin, file.toExtracted)
-        case _          => error("Plugin archive not found")
-
-      }
+      val file = dependencies.plugin.fetch(plugin)
+      PluginArchive(plugin, file.toExtracted)
     })
 
     val distinctPlugins = archives.reverse.distinctBy(_.rootEntries).reverse
@@ -150,13 +146,9 @@ final case class IntelliJFactory(
 
   private def installIntelliJ(version: IntelliJVersion, root: Path): Unit = {
     println(s"Installing $version")
-    val fileOpt = dependencies.intelliJ.fetch(version)
-    fileOpt match {
-      case Some(file) =>
-        file.toExtracted.installTo(root)
-        root.resolve("bin").makeExecutableRecursively()
-      case None => error("Intellij artifacts not found")
-    }
+    val file = dependencies.intelliJ.fetch(version)
+    file.toExtracted.installTo(root)
+    root.resolve("bin").makeExecutableRecursively()
   }
 }
 


### PR DESCRIPTION
FileDownloader relies directly on uri, completely ignoring createStream parameter. It breaks building plugin from sources and loading plugins from jars, like bundled plugins (ide-probe extensions are broken). Loading plugins from jars is because FileDownloader asserts that URL returns a HTTP connection, while JarConnection is something else.

I also fixed problematic api like fetch returning option while fetchOpt also exists. 
BenchmarkReporter should be parametrized with type rather than `report` method. In original state there was no type information. 