### PR TITLE
add automated intellij version bump

### DIFF
--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -8,26 +8,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        # with:
-        #   token: 'add_secret_variable_with_bot's_personal_access_token_here'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update default IntelliJ version
         run: |
           sbt "update-intellij / run --java-home /usr/local/openjdk-11"
-          # git config user.name BOT_USER_NAME
-          # git config user.email BOT_USER_EMAIL
-          # git add .
-          ## `cut -c 14-` extracts intellij version from line starting with "latestStable=" (like "latestStable=2021.2.1")
-          ## // TODO - cope with situations where there is nothing to commit ...
-          # git commit -m "updated default IntelliJ version to $INTELLIJ_VERSION"
-          # git push
-          # echo "Adding comment to the pull request..."
-          # curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          # echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
-          #   https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          # apt update
-          # apt install gh -y
-          # echo $BOT_TOKEN | gh auth login --with-token // TODO set BOT_TOKEN
-          # PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
-          # COMMENT_BODY="" // TODO ADD COMMENT - MENTION https://plugins.jetbrains.com/plugin/1347-scala/versions
-          # gh pr comment $PR_NUMBER --body $COMMENT_BODY 
-          
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          if [[ -n $(git status | grep 'modified') ]]
+          then
+            RELEASE_LINE=$(grep 'release = \"' core/driver/sources/src/main/resources/reference.conf)
+            INTELLIJ_VERSION=$(awk -F'\"|\"' '{print $2}' <<< "$RELEASE_LINE")
+            git commit -m "updated default IntelliJ version to $INTELLIJ_VERSION"
+            COMMIT_SHA=$(git rev-parse HEAD)
+            git fetch
+            git checkout $GITHUB_BASE_REF
+            BRANCH_NAME="update_intellij_version_to_$INTELLIJ_VERSION"
+            git branch $BRANCH_NAME
+            git checkout $BRANCH_NAME
+            git cherry-pick $COMMIT_SHA
+            git push --set-upstream origin $BRANCH_NAME
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+              https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            apt update
+            apt install gh -y
+            echo $GITHUB_TOKEN | gh auth login --with-token
+            PR_TITLE="Update IntelliJ version to $INTELLIJ_VERSION"
+            SCALA_PLUGIN_FILE_URL="https://github.com/VirtusLab/ide-probe/blob/master/extensions/scala/tests/src/test/resources/scala.conf"
+            SCALA_PLUGIN_VERSIONS_URL="https://plugins.jetbrains.com/plugin/1347-scala/versions"
+            PR_BODY="Updates the default IntelliJ Version to the newest release. \
+              Please, check currently used version of the scala plugin: $SCALA_PLUGIN_FILE_URL \
+              and verify if it is compatible with the new intelliJ IDEA version ($INTELLIJ_VERSION) here: $SCALA_PLUGIN_VERSIONS_URL. \
+              If the version of the scala plugin used in $SCALA_PLUGIN_FILE_URL is NOT compatible - please update it in a separate commit."
+            gh pr create --title $PR_TITLE --body $PR_BODY
+          fi

--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -1,0 +1,33 @@
+name: Update IntelliJ Version
+
+on:
+  pull_request:
+
+jobs:
+  bump-intellij-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+        # with:
+        #   token: 'add_secret_variable_with_bot's_personal_access_token_here'
+      - name: Update default IntelliJ version
+        run: |
+          sbt "update-intellij / run --java-home /usr/local/openjdk-11"
+          # git config user.name BOT_USER_NAME
+          # git config user.email BOT_USER_EMAIL
+          # git add .
+          ## `cut -c 14-` extracts intellij version from line starting with "latestStable=" (like "latestStable=2021.2.1")
+          ## // TODO - cope with situations where there is nothing to commit ...
+          # git commit -m "updated default IntelliJ version to $INTELLIJ_VERSION"
+          # git push
+          # echo "Adding comment to the pull request..."
+          # curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          # echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+          #   https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          # apt update
+          # apt install gh -y
+          # echo $BOT_TOKEN | gh auth login --with-token // TODO set BOT_TOKEN
+          # PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          # COMMENT_BODY="" // TODO ADD COMMENT - MENTION https://plugins.jetbrains.com/plugin/1347-scala/versions
+          # gh pr comment $PR_NUMBER --body $COMMENT_BODY 
+          

--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -1,47 +1,33 @@
 name: Update IntelliJ Version
 
 on:
-  pull_request:
+  schedule:
+    - cron: '0 1 * * 1'
 
 jobs:
   bump-intellij-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3.0.2
       - name: Update default IntelliJ version
         run: |
           sbt "update-intellij / run --java-home /usr/local/openjdk-11"
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          if [[ -n $(git status | grep 'modified') ]]
-          then
-            RELEASE_LINE=$(grep 'release = \"' core/driver/sources/src/main/resources/reference.conf)
-            INTELLIJ_VERSION=$(awk -F'\"|\"' '{print $2}' <<< "$RELEASE_LINE")
-            git commit -m "updated default IntelliJ version to $INTELLIJ_VERSION"
-            COMMIT_SHA=$(git rev-parse HEAD)
-            git fetch
-            git checkout $GITHUB_BASE_REF
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
-              https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt update
-            sudo apt install gh -y
-            gh repo fork --remote=true
-            BRANCH_NAME="update_intellij_version_to_$INTELLIJ_VERSION"
-            git branch $BRANCH_NAME
-            git checkout $BRANCH_NAME
-            git cherry-pick $COMMIT_SHA
-            git push --set-upstream origin $BRANCH_NAME
-            echo $GITHUB_TOKEN | gh auth login --with-token
-            PR_TITLE="Update IntelliJ version to $INTELLIJ_VERSION"
-            SCALA_PLUGIN_FILE_URL="https://github.com/VirtusLab/ide-probe/blob/master/extensions/scala/tests/src/test/resources/scala.conf"
-            SCALA_PLUGIN_VERSIONS_URL="https://plugins.jetbrains.com/plugin/1347-scala/versions"
-            PR_BODY="Updates the default IntelliJ Version to the newest release. \
-              Please, check currently used version of the scala plugin: $SCALA_PLUGIN_FILE_URL \
-              and verify if it is compatible with the new intelliJ IDEA version ($INTELLIJ_VERSION) here: $SCALA_PLUGIN_VERSIONS_URL. \
-              If the version of the scala plugin used in $SCALA_PLUGIN_FILE_URL is NOT compatible - please update it in a separate commit."
-            gh pr create --title $PR_TITLE --body $PR_BODY
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare variables for PR
+        run: |
+          RELEASE_LINE=$(grep 'release = \"' core/driver/sources/src/main/resources/reference.conf)
+          INTELLIJ_VERSION=$(awk -F'\"|\"' '{print $2}' <<< "$RELEASE_LINE")
+          echo "BRANCH_NAME=update_intellij_version_to_$INTELLIJ_VERSION >> $GITHUB_ENV
+          echo "PR_TITLE=Update IntelliJ version to $INTELLIJ_VERSION" >> $GITHUB_ENV
+          SCALA_PLUGIN_FILE_URL="https://github.com/VirtusLab/ide-probe/blob/master/extensions/scala/tests/src/test/resources/scala.conf"
+          SCALA_PLUGIN_VERSIONS_URL="https://plugins.jetbrains.com/plugin/1347-scala/versions"
+          echo "PR_BODY=Updates the default IntelliJ Version to the newest release. \
+            Please, check currently used version of the scala plugin: $SCALA_PLUGIN_FILE_URL \
+            and verify if it is compatible with the new intelliJ IDEA version ($INTELLIJ_VERSION) here: $SCALA_PLUGIN_VERSIONS_URL. \
+            If the version of the scala plugin used in $SCALA_PLUGIN_FILE_URL is NOT compatible - please update it in a separate commit." >> $GITHUB_ENV
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: ${{ env.BRANCH_NAME }}
+          base: "master"
+          title: ${{ env.PR_TITLE }}
+          body: ${{ env.PR_BODY }}

--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -13,17 +13,18 @@ jobs:
         run: |
           sbt "update-intellij / run --java-home /usr/local/openjdk-11"
       - name: Prepare variables for PR
+        # language=sh
         run: |
-          RELEASE_LINE=$(grep 'release = \"' core/driver/sources/src/main/resources/reference.conf)
-          INTELLIJ_VERSION=$(awk -F'\"|\"' '{print $2}' <<< "$RELEASE_LINE")
-          echo "BRANCH_NAME=update_intellij_version_to_$INTELLIJ_VERSION >> $GITHUB_ENV
-          echo "PR_TITLE=Update IntelliJ version to $INTELLIJ_VERSION" >> $GITHUB_ENV
-          SCALA_PLUGIN_FILE_URL="https://github.com/VirtusLab/ide-probe/blob/master/extensions/scala/tests/src/test/resources/scala.conf"
-          SCALA_PLUGIN_VERSIONS_URL="https://plugins.jetbrains.com/plugin/1347-scala/versions"
+          release_line=$(grep 'release = \"' core/driver/sources/src/main/resources/reference.conf)
+          intellij_version=$(awk -F'\"|\"' '{print $2}' <<< "$release_line")
+          echo "BRANCH_NAME=update_intellij_version_to_$intellij_version" >> $GITHUB_ENV
+          echo "PR_TITLE=Update IntelliJ version to $intellij_version" >> $GITHUB_ENV
+          scala_plugin_file_url="https://github.com/VirtusLab/ide-probe/blob/master/extensions/scala/tests/src/test/resources/scala.conf"
+          scala_plugin_versions_url="https://plugins.jetbrains.com/plugin/1347-scala/versions"
           echo "PR_BODY=Updates the default IntelliJ Version to the newest release. \
-            Please, check currently used version of the scala plugin: $SCALA_PLUGIN_FILE_URL \
-            and verify if it is compatible with the new intelliJ IDEA version ($INTELLIJ_VERSION) here: $SCALA_PLUGIN_VERSIONS_URL. \
-            If the version of the scala plugin used in $SCALA_PLUGIN_FILE_URL is NOT compatible - please update it in a separate commit." >> $GITHUB_ENV
+            Please, check currently used version of the scala plugin: $scala_plugin_file_url \
+            and verify if it is compatible with the new intelliJ IDEA version ($intellij_version) here: $scala_plugin_versions_url. \
+            If the version of the scala plugin used in $scala_plugin_file_url is NOT compatible - please update it in a separate commit." >> $GITHUB_ENV
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:

--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -2,7 +2,7 @@ name: Update IntelliJ Version
 
 on:
   schedule:
-    - cron: '0 1 * * 1'  # at 01:00 UTC on mondays
+    - cron: '0 0 * * *'  # at 00:00 UTC daily
 
 jobs:
   bump-intellij-version:

--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -2,7 +2,7 @@ name: Update IntelliJ Version
 
 on:
   schedule:
-    - cron: '0 1 * * 1'
+    - cron: '0 1 * * 1'  # at 01:00 UTC on mondays
 
 jobs:
   bump-intellij-version:
@@ -16,8 +16,8 @@ jobs:
         # language=sh
         run: |
           release_line=$(grep 'release = \"' core/driver/sources/src/main/resources/reference.conf)
-          intellij_version=$(awk -F'\"|\"' '{print $2}' <<< "$release_line")
-          echo "BRANCH_NAME=update_intellij_version_to_$intellij_version" >> $GITHUB_ENV
+          intellij_version=$(cut -d'"' -f2 <<< "$release_line")
+          echo "BRANCH_NAME=update_intellij_version/$intellij_version" >> $GITHUB_ENV
           echo "PR_TITLE=Update IntelliJ version to $intellij_version" >> $GITHUB_ENV
           scala_plugin_file_url="https://github.com/VirtusLab/ide-probe/blob/master/extensions/scala/tests/src/test/resources/scala.conf"
           scala_plugin_versions_url="https://plugins.jetbrains.com/plugin/1347-scala/versions"
@@ -30,5 +30,6 @@ jobs:
         with:
           branch: ${{ env.BRANCH_NAME }}
           base: "master"
+          commit-message: ${{ env.PR_TITLE }}
           title: ${{ env.PR_TITLE }}
           body: ${{ env.PR_BODY }}

--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update default IntelliJ version
         run: |
           sbt "update-intellij / run --java-home /usr/local/openjdk-11"
@@ -24,16 +22,17 @@ jobs:
             COMMIT_SHA=$(git rev-parse HEAD)
             git fetch
             git checkout $GITHUB_BASE_REF
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+              https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt update
+            sudo apt install gh -y
+            gh repo fork --remote=true
             BRANCH_NAME="update_intellij_version_to_$INTELLIJ_VERSION"
             git branch $BRANCH_NAME
             git checkout $BRANCH_NAME
             git cherry-pick $COMMIT_SHA
             git push --set-upstream origin $BRANCH_NAME
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
-              https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            apt update
-            apt install gh -y
             echo $GITHUB_TOKEN | gh auth login --with-token
             PR_TITLE="Update IntelliJ version to $INTELLIJ_VERSION"
             SCALA_PLUGIN_FILE_URL="https://github.com/VirtusLab/ide-probe/blob/master/extensions/scala/tests/src/test/resources/scala.conf"
@@ -44,3 +43,5 @@ jobs:
               If the version of the scala plugin used in $SCALA_PLUGIN_FILE_URL is NOT compatible - please update it in a separate commit."
             gh pr create --title $PR_TITLE --body $PR_BODY
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sbt
+++ b/build.sbt
@@ -285,6 +285,9 @@ lazy val benchmarks = module("benchmarks", "benchmarks").cross
 
 lazy val benchmarks213 = benchmarks(scala213)
 
+lazy val updateIntellij = project("update-intellij", "ci/update-intellij", publish = false)
+  .settings(libraryDependencies += Dependencies.jsoup)
+
 val commonSettings = Seq(
   libraryDependencies ++= Dependencies.junit
 )

--- a/ci/update-intellij/src/main/resources/intellijVersion.properties
+++ b/ci/update-intellij/src/main/resources/intellijVersion.properties
@@ -1,4 +1,0 @@
-#Thu Aug 18 00:07:22 UTC 2022
-# Values below must match intellij version values from the reference.conf file. DO NOT CHANGE MANUALLY.
-latestRelease=2021.2.1
-connectedBuildNumber=212.5080.55

--- a/ci/update-intellij/src/main/resources/intellijVersion.properties
+++ b/ci/update-intellij/src/main/resources/intellijVersion.properties
@@ -1,0 +1,4 @@
+#Thu Aug 18 00:07:22 UTC 2022
+# Values below must match intellij version values from the reference.conf file. DO NOT CHANGE MANUALLY.
+latestRelease=2021.2.1
+connectedBuildNumber=212.5080.55

--- a/ci/update-intellij/src/main/scala/org.virtuslab.ideprobe/BumpIntelliJ.scala
+++ b/ci/update-intellij/src/main/scala/org.virtuslab.ideprobe/BumpIntelliJ.scala
@@ -1,0 +1,86 @@
+package org.virtuslab.ideprobe
+
+import java.io.File
+import java.io.PrintWriter
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+import scala.io.Source
+import scala.jdk.CollectionConverters._
+
+import org.jsoup.Jsoup
+
+object BumpIntelliJ extends App {
+  private val fileName = "intellijVersion.properties"
+  private val releaseRegex = """20\d\d.\d.?\d?"""
+
+  val filesToUpdate = Seq(
+    new File("ci/update-intellij/src/main/resources/intellijVersion.properties"),
+    new File("core/driver/sources/src/main/resources/reference.conf"),
+    new File("core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/IdeProbeConfigTest.scala")
+  )
+
+  private val intellijReleaseFromCode = getValueFromIntellijVersionFile("latestRelease")
+  private val intellijBuildNumberFromCode = getValueFromIntellijVersionFile("connectedBuildNumber")
+
+  private val officialIntellijReleaseLinks: List[String] =
+    Jsoup
+      .connect("https://www.jetbrains.com/intellij-repository/releases/")
+      .get()
+      .select(
+        "a[href^=https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/ideaIC/][href$=.pom]"
+      )
+      .eachAttr("href")
+      .asScala
+      .toList
+
+  private val officialIntellijReleases =
+    officialIntellijReleaseLinks
+      .map(link => link.substring(link.indexOf("ideaIC-"), link.indexOf(".pom")).replace("ideaIC-", ""))
+      .filter(_.matches(releaseRegex))
+
+  private val newestStableRelease = officialIntellijReleases.max
+
+  private lazy val newestStableReleasePomLink = officialIntellijReleaseLinks.find(_.contains(newestStableRelease)).get
+  private lazy val newestStableBuildNumber = {
+    def replaceIdeaICPomFileNameWithBuildTxt(ideaICpomFileName: String): String =
+      ideaICpomFileName
+        .replace("ideaIC-", "BUILD-")
+        .replace(".pom", ".txt")
+        .replace("ideaIC", "BUILD")
+
+    val newestStableBuildNumberFileURL = new URL(replaceIdeaICPomFileNameWithBuildTxt(newestStableReleasePomLink))
+    Source.fromURL(newestStableBuildNumberFileURL).mkString
+  }
+
+  if (newestStableRelease > intellijReleaseFromCode) filesToUpdate.foreach(bumpIntellijVersion)
+
+  private def bumpIntellijVersion(oldFile: File): Unit = {
+    val newFile = new File("/tmp/bump_version.txt")
+    val w = new PrintWriter(newFile)
+    Source
+      .fromFile(oldFile)
+      .getLines()
+      .map { line =>
+        if (line.contains(intellijReleaseFromCode)) line.replace(intellijReleaseFromCode, newestStableRelease) else line
+      }
+      .map { line =>
+        if (line.contains(intellijBuildNumberFromCode))
+          line.replace(intellijBuildNumberFromCode, newestStableBuildNumber)
+        else line
+      }
+      .foreach(x => w.println(x))
+    w.close()
+    Files.move(newFile.toPath, oldFile.toPath, REPLACE_EXISTING)
+  }
+
+  private def getValueFromIntellijVersionFile(key: String): String = Source
+    .fromResource(fileName)
+    .getLines()
+    .toList
+    .find(_.contains(key))
+    .get
+    .substring(key.length + 1) // to extract VALUE from "$key=VALUE" line
+
+}

--- a/ci/update-intellij/src/main/scala/org.virtuslab.ideprobe/BumpIntelliJ.scala
+++ b/ci/update-intellij/src/main/scala/org.virtuslab.ideprobe/BumpIntelliJ.scala
@@ -84,10 +84,17 @@ object BumpIntelliJ extends App {
     .fromFile(referenceConfFile)
     .getLines()
     .toList
-    .find(_.contains(charsUntilValue))
+    .find(line => line.contains(charsUntilValue) && isNotHoconComment(line, charsUntilValue))
     .get
     .trim
     .substring(charsUntilValue.length)
     .init // to drop the last double-quote character from the string value
+
+  private def isNotHoconComment(line: String, keyChars: String): Boolean = {
+    val commentStrings = Seq("//", "#")
+    commentStrings.forall { commentString =>
+      line.indexOf(commentString) == -1 || line.indexOf(keyChars) < line.indexOf(commentString)
+    }
+  }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,6 +28,8 @@ object Dependencies {
 
   val gson = "com.google.code.gson" % "gson" % "2.9.1"
 
+  val jsoup = "org.jsoup" % "jsoup" % "1.15.3"
+
   val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1" % Compile
 
   // because idea plugin packager would only take the root jar which has no classes


### PR DESCRIPTION
Closes #256
Added scheduled job that would run daily (later to be changed to once a week) to search for new intelliJ release and create a PR if a newer release was found.