### PR TITLE
Make git clone logging less verbose

### DIFF
--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/git/GitHandler.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/git/GitHandler.scala
@@ -86,10 +86,10 @@ object GitHandler {
       if (System.getenv("CI") == "true") // should always be "true" for github actions workflow
         printForCI(title, completed, total)
       else
-        printForNoCI(title, completed, total)
+        printForNonCI(title, completed, total)
     }
 
-    private def printForNoCI(title: String, completed: Int, total: Int): Unit = {
+    private def printForNonCI(title: String, completed: Int, total: Int): Unit = {
       val inner =
         if (total == 0)
           ""

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/git/GitHandler.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/git/GitHandler.scala
@@ -83,13 +83,32 @@ object GitHandler {
     private def printProgress(completed: Int): Unit = {
       val total = totalWork.get()
       val title = task.get()
+      if (System.getenv("CI") == "true") // should always be "true" for github actions workflow
+        printForCI(title, completed, total)
+      else
+        printForNoCI(title, completed, total)
+    }
 
-      if (total == 0) return
+    private def printForNoCI(title: String, completed: Int, total: Int): Unit = {
+      val inner =
+        if (total == 0)
+          ""
+        else if (completed == total)
+          s"$title 100% ($total/$total)\n"
+        else {
+          val percent = (100 * completed) / total
+          s"$title $percent% ($completed/$total)"
+        }
+      print(s"\r$inner")
+    }
 
-      val percent = (100 * completed) / total
-      if (!titlePercentArray.contains((title, percent))) { // to print only one line per 1 percent in logs
-        titlePercentArray += (title -> percent)
-        println(s"$title $percent% ($completed/$total)")
+    private def printForCI(title: String, completed: Int, total: Int): Unit = {
+      if (total != 0) {
+        val percent = (100 * completed) / total
+        if (!titlePercentArray.contains((title, percent))) { // print only one line per 1 percent in logs
+          titlePercentArray += (title -> percent)
+          println(s"$title $percent% ($completed/$total)")
+        }
       }
     }
 

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/git/GitHandler.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/git/GitHandler.scala
@@ -86,14 +86,10 @@ object GitHandler {
 
       if (total == 0) return
 
-      if (completed == total) {
-        println(s"$title 100% ($total/$total)")
-      } else {
-        val percent = (100 * completed) / total
-        if (!titlePercentArray.contains((title, percent))) { // to print only one line per 1 percent in logs
-          titlePercentArray += (title -> percent)
-          println(s"$title $percent% ($completed/$total)")
-        }
+      val percent = (100 * completed) / total
+      if (!titlePercentArray.contains((title, percent))) { // to print only one line per 1 percent in logs
+        titlePercentArray += (title -> percent)
+        println(s"$title $percent% ($completed/$total)")
       }
     }
 

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/git/GitHandler.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/git/GitHandler.scala
@@ -86,10 +86,14 @@ object GitHandler {
 
       if (total == 0) return
 
-      val percent = (100 * completed) / total
-      if (!titlePercentArray.contains((title, percent))) { // to print only one line per 1 percent in logs
-        titlePercentArray += (title -> percent)
-        println(s"$title $percent% ($completed/$total)")
+      if (completed == total) {
+        println(s"$title 100% ($total/$total)")
+      } else {
+        val percent = (100 * completed) / total
+        if (!titlePercentArray.contains((title, percent))) { // to print only one line per 1 percent in logs
+          titlePercentArray += (title -> percent)
+          println(s"$title $percent% ($completed/$total)")
+        }
       }
     }
 


### PR DESCRIPTION
Closes #274

These changes fix logging of `git-clone` related logs - so that there will be only one line logged for 1% of progress. Changes shorten the total log length for `tests (2.12, probe)` and `tests (2.13 probe)` from 24.000+ lines to less than 3.500 lines.