### PR TITLE
Add support for installing IntelliJ from .dmg

### DIFF
--- a/core/driver/sources/src/main/resources/reference.conf
+++ b/core/driver/sources/src/main/resources/reference.conf
@@ -17,7 +17,7 @@ probe {
       // `ext` stands for the file extension (file format). This config specifies which extension should be
       // downloaded and installed. By default, ".zip" distributions of IntelliJ IDEA are downloaded. For now
       // two extensions are supported: ".zip" and ".dmg". ".zip" is the default one whereas ".dmg" shuld be used
-      // for osx only.
+      // for Mac OS X only.
       ext = ".zip"
       # ext = ".dmg"
 

--- a/core/driver/sources/src/main/resources/reference.conf
+++ b/core/driver/sources/src/main/resources/reference.conf
@@ -16,8 +16,10 @@ probe {
 
       // `ext` stands for the file extension (file format). This config specifies which extension should be
       // downloaded and installed. By default, ".zip" distributions of IntelliJ IDEA are downloaded. For now
-      // only ".zip" extension is supported.
+      // two extensions are supported: ".zip" and ".dmg". ".zip" is the default one whereas ".dmg" shuld be used
+      // for osx only.
       ext = ".zip"
+      # ext = ".dmg"
 
     }
 
@@ -96,8 +98,8 @@ probe {
     // ]
     //
     // Moreover, you can add a pattern pointing to a directory of an installed IntelliJ instance instead of
-    // pattern pointing to a .zip file. ide-probe will recognize if the pattern points to a directory with
-    // installed IntelliJ or to a .zip file. For example, if you run the IntelliJ Plugin Verifier on your
+    // pattern pointing to a .zip (or .dmg) file. ide-probe will recognize if the pattern points to a directory with
+    // installed IntelliJ or to a .zip (or .dmg) file. For example, if you run the IntelliJ Plugin Verifier on your
     // repository (https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#tasks-runpluginverifier),
     // then you could use following configuration:
     // intellij.repositories = [

--- a/core/driver/sources/src/main/resources/reference.conf
+++ b/core/driver/sources/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ probe {
 
       // `ext` stands for the file extension (file format). This config specifies which extension should be
       // downloaded and installed. By default, ".zip" distributions of IntelliJ IDEA are downloaded. For now
-      // two extensions are supported: ".zip" and ".dmg". ".zip" is the default one whereas ".dmg" shuld be used
+      // two extensions are supported: ".zip" and ".dmg". ".zip" is the default one whereas ".dmg" should be used
       // for Mac OS X only.
       ext = ".zip"
       # ext = ".dmg"

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Resource.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Resource.scala
@@ -92,8 +92,9 @@ object Resource extends ConfigFormat {
       import sys.process._
 
       // create tmp directory where disk image will be attached
-      val dmgDir = Paths.get(System.getProperty("java.io.tmpdir")).resolve("dmg_dir")
-      dmgDir.createDirectory()
+      val dmgDirPath = Paths.get(System.getProperty("java.io.tmpdir")).resolve("dmg_dir")
+      dmgDirPath.createDirectory()
+      val dmgDir = dmgDirPath.toString
 
       try {
         // attach disk image from .dmg file to local filesystem

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Resource.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/Resource.scala
@@ -91,17 +91,21 @@ object Resource extends ConfigFormat {
     def installTo(target: Path): Unit = {
       import sys.process._
 
-      // attach disk image from .dmg file to local filesystem
-      val dmgDir = s"${System.getProperty("java.io.tmpdir")}dmg_dir"
-      s"mkdir $dmgDir".!
-      s"hdiutil attach -mountpoint $dmgDir ${path.toString}".!
+      // create tmp directory where disk image will be attached
+      val dmgDir = Paths.get(System.getProperty("java.io.tmpdir")).resolve("dmg_dir")
+      dmgDir.createDirectory()
 
-      // copy $dmgDir/IntelliJ IDEA CE.app to proper installation directory
-      val idePath = Paths.get(s"$dmgDir/IntelliJ IDEA CE.app/Contents")
-      idePath.copyDir(target)
+      try {
+        // attach disk image from .dmg file to local filesystem
+        s"hdiutil attach -mountpoint $dmgDir ${path.toString}".!
+        // copy $dmgDir/IntelliJ IDEA CE.app/ to proper installation directory
+        val idePath = Paths.get(s"$dmgDir/IntelliJ IDEA CE.app/Contents")
+        idePath.copyDir(target)
+      } finally {
+        // detach disk image from local filesystem
+        s"hdiutil detach $dmgDir".!
+      }
 
-      // detach disk image from local filesystem
-      s"hdiutil detach $dmgDir".!
     }
   }
 

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/ResourceProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/ResourceProvider.scala
@@ -60,7 +60,6 @@ object ResourceProvider {
         retries: Int
     ): Path = {
       val cachedResource = cached(uri)
-      println(s"\ncached is:\n$cachedResource\n")
       if (!cachedResource.isFile) {
         retry(retries) { () =>
           val stream = createStream()

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/ResourceProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/ResourceProvider.scala
@@ -60,6 +60,7 @@ object ResourceProvider {
         retries: Int
     ): Path = {
       val cachedResource = cached(uri)
+      println(s"\ncached is:\n$cachedResource\n")
       if (!cachedResource.isFile) {
         retry(retries) { () =>
           val stream = createStream()
@@ -75,8 +76,9 @@ object ResourceProvider {
 
     private def cached(uri: URI): Path = {
       val resultPath = directory.resolve(Hash.md5(uri.toString))
-      if (uri.toString.endsWith(".dmg"))
-        Paths.get(resultPath.toString + ".dmg") // needed for `object DMGFile`'s unapply logic
+      val uriExtensionIndex = uri.toString.lastIndexOf('.')
+      if (uriExtensionIndex != -1)
+        Paths.get(resultPath.toString + uri.toString.substring(uriExtensionIndex)) // keep extension in cached file name
       else
         resultPath
     }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/ResourceProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/dependencies/ResourceProvider.scala
@@ -4,6 +4,7 @@ import java.io.InputStream
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.Paths
 
 import scala.annotation.tailrec
 
@@ -73,7 +74,11 @@ object ResourceProvider {
     }
 
     private def cached(uri: URI): Path = {
-      directory.resolve(Hash.md5(uri.toString))
+      val resultPath = directory.resolve(Hash.md5(uri.toString))
+      if (uri.toString.endsWith(".dmg"))
+        Paths.get(resultPath.toString + ".dmg") // needed for `object DMGFile`'s unapply logic
+      else
+        resultPath
     }
   }
 }

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
@@ -148,14 +148,8 @@ final case class IntelliJFactory(
     println(s"Installing $version")
     val file = dependencies.intelliJ.fetch(version)
     file.toExtracted.installTo(root)
-    if (installedFromOsxDmg(root))
-      root.resolve("MacOS/idea").makeExecutable()
-    else
-      root.resolve("bin").makeExecutableRecursively()
+    root.resolve("bin").makeExecutableRecursively()
   }
-
-  private def installedFromOsxDmg(path: Path): Boolean = path.directChildren().exists(_.name == "MacOS")
-
 }
 
 object IntelliJProvider {

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
@@ -156,8 +156,14 @@ final case class IntelliJFactory(
     println(s"Installing $version")
     val file = dependencies.intelliJ.fetch(version)
     file.toExtracted.installTo(root)
-    root.resolve("bin").makeExecutableRecursively()
+    if (installedFromOsxDmg(root))
+      root.resolve("MacOS/idea").makeExecutable()
+    else
+      root.resolve("bin").makeExecutableRecursively()
   }
+
+  private def installedFromOsxDmg(path: Path): Boolean = path.directChildren().exists(_.name == "MacOS")
+
 }
 
 object IntelliJProvider {


### PR DESCRIPTION
Closes #281

Tested locally against `git-machete-intellij-plugin` - all tests pass properly with following config:
```
probe.resolvers {
    intellij.repositories = [
      "https://download.jetbrains.com/idea/ideaIC-2022.2.2.dmg"
    ]
  }
```

to be done:
- [x] add description for users in `reference.conf`