### PR TITLE
Fix `update intellij version` pull requests

### DIFF
--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -33,4 +33,5 @@ jobs:
           commit-message: ${{ env.PR_TITLE }}
           title: ${{ env.PR_TITLE }}
           body: ${{ env.PR_BODY }}
-          author: "GitHub <noreply@github.com>"
+          author: "virtuslab-bot <virtuslab-bot@users.noreply.github.com>"
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -33,5 +33,5 @@ jobs:
           commit-message: ${{ env.PR_TITLE }}
           title: ${{ env.PR_TITLE }}
           body: ${{ env.PR_BODY }}
-          author: "virtuslab-bot <virtuslab-bot@users.noreply.github.com>"
+          author: "virtuslab-bot <74701374+virtuslab-bot@users.noreply.github.com>"
           token: ${{ secrets.BOT_ACCESS_TOKEN }}

--- a/.github/workflows/update-intellij-version.yml
+++ b/.github/workflows/update-intellij-version.yml
@@ -33,3 +33,4 @@ jobs:
           commit-message: ${{ env.PR_TITLE }}
           title: ${{ env.PR_TITLE }}
           body: ${{ env.PR_BODY }}
+          author: "GitHub <noreply@github.com>"


### PR DESCRIPTION
Fixes pull requests like this one https://github.com/VirtusLab/ide-probe/pull/286 so that:
- commit author will be set as the bot user
- github actions workflows (CI tests) will be started

The `BOT_ACCESS_TOKEN` is added to secrets. It is a personal access token for the virtuslab-bot user