### PR TITLE
Fix IntelliJ cleanup logic for macOs

### DIFF
--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
@@ -227,7 +227,10 @@ final class DownloadedIntelliJ(
     probePaths.logExport.foreach { path =>
       paths.logs.copyDir(path.resolve(getPathWithVersionNumber(root)).resolve("logs"))
     }
-    root.delete()
+    if (OS.Current == OS.Mac && root.name == "Contents")
+      root.getParent.delete()
+    else
+      root.delete()
   }
 
   /*

--- a/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/SingleRunFixtureTest.scala
+++ b/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/SingleRunFixtureTest.scala
@@ -1,7 +1,5 @@
 package org.virtuslab.ideprobe.dependencies
 
-import org.virtuslab.ideprobe.OS
-
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -21,6 +19,7 @@ import org.virtuslab.ideprobe.Config
 import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe.IdeProbeFixture
 import org.virtuslab.ideprobe.IntelliJFixture
+import org.virtuslab.ideprobe.OS
 import org.virtuslab.ideprobe.Shell
 import org.virtuslab.ideprobe.SingleRunIntelliJ
 

--- a/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/SingleRunFixtureTest.scala
+++ b/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/SingleRunFixtureTest.scala
@@ -1,5 +1,7 @@
 package org.virtuslab.ideprobe.dependencies
 
+import org.virtuslab.ideprobe.OS
+
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -19,7 +21,6 @@ import org.virtuslab.ideprobe.Config
 import org.virtuslab.ideprobe.Extensions._
 import org.virtuslab.ideprobe.IdeProbeFixture
 import org.virtuslab.ideprobe.IntelliJFixture
-import org.virtuslab.ideprobe.OS
 import org.virtuslab.ideprobe.Shell
 import org.virtuslab.ideprobe.SingleRunIntelliJ
 
@@ -56,8 +57,9 @@ final class SingleRunFixtureTest extends IdeProbeFixture with WorkspaceFixture w
 
   @Test
   def removesDirectoriesEvenAfterFailureToRunIntelliJ(): Unit = {
+    val intellijLauncher = if (OS.Current == OS.Mac) "idea" else "idea.sh"
     val intelliJFixture = IntelliJFixture().withAfterIntelliJInstall((_, intellij) =>
-      Files.delete(intellij.paths.root.resolve("bin").resolve("idea.sh")) // To prevent the IDE from launching.
+      Files.delete(intellij.paths.root.resolve("bin").resolve(intellijLauncher)) // To prevent the IDE from launching.
     )
 
     val instancesDir = intelliJFixture.intelliJProvider.paths.instances


### PR DESCRIPTION
Related to https://github.com/VirtusLab/ide-probe/issues/238 (but does **not** close it).

Fixes IntelliJ cleanup logic for macOs and makes `SingleRunFixtureTest` tests succeed on macOs **if** `.dmg` extension is used as `probe.intellij.version.ext`.