### PR TITLE
Handle ProgressIndicatorEx as not named bg task

### DIFF
--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/wait/WaitLogicFactory.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/wait/WaitLogicFactory.scala
@@ -88,7 +88,7 @@ trait WaitLogicFactory {
     ) { currentTasks =>
       val ignorePatterns = Seq(
         "<unknown>".r,
-        """ProgressIndicator \d+: .*""".r,
+        """ProgressIndicator(?:Ex)? \d+: .*""".r,
         """com\.intellij\.openapi\.progress\.EmptyProgressIndicator@.{8}""".r
       )
       def isNamedTask(task: String): Boolean =


### PR DESCRIPTION
IntelliJ now also reports tasks throught ProgessIndicatorEx (compared to ProgressIndicator without ex). Now these are recongised as named background tasks, while they should not be.