### PR TITLE
Store plugins (robot, ide-probe, the tested plugin) in a directory separate from where bundled plugins live

### DIFF
--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/InstalledIntelliJ.scala
@@ -205,7 +205,7 @@ final class LocalIntelliJ(
 
   override def cleanup(): Unit = {
     cleanupIdeaProperties()
-    val pluginsDir = root.resolve("plugins")
+    val pluginsDir = paths.plugins
     pluginsDir.delete()
     pluginsBackup.moveTo(pluginsDir)
     vmoptions.delete()

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJPaths.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJPaths.scala
@@ -14,7 +14,7 @@ final case class IntelliJPaths(
     userPrefs: Path
 ) {
   val bin: Path = root.resolve("bin")
-  val bundledPlugins = root.resolve("plugins")
+  val bundledPlugins: Path = root.resolve("plugins")
 }
 
 object IntelliJPaths {

--- a/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
+++ b/core/driver/sources/src/main/scala/org/virtuslab/ideprobe/ide/intellij/IntelliJProvider.scala
@@ -39,7 +39,7 @@ sealed trait IntelliJProvider {
       val rootEntries: Set[String] = archive.rootEntries.toSet
     }
 
-    val targetDir = intelliJ.paths.bundledPlugins
+    val targetDir = intelliJ.paths.plugins
     val archives = withParallel[Plugin, PluginArchive](allPlugins)(_.map { plugin =>
       val file = dependencies.plugin.fetch(plugin)
       PluginArchive(plugin, file.toExtracted)
@@ -85,7 +85,7 @@ final case class ExistingIntelliJ(
 
   override def setup(): InstalledIntelliJ = {
     val intelliJPaths = IntelliJPaths.fromExistingInstance(path)
-    val pluginsDir = intelliJPaths.bundledPlugins
+    val pluginsDir = intelliJPaths.plugins
     val backupDir = Files.createTempDirectory(path, "plugins")
     val intelliJ = new LocalIntelliJ(path, paths, config, intelliJPaths, backupDir)
     pluginsDir.copyDir(backupDir)

--- a/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/IntelliJProviderTest.scala
+++ b/core/driver/sources/src/test/scala/org/virtuslab/ideprobe/dependencies/IntelliJProviderTest.scala
@@ -83,7 +83,7 @@ final class IntelliJProviderTest {
   @Test
   def existingIntelliJShouldRetainItsOriginalPluginsDuringCleanup(): Unit = givenInstalledIntelliJ { installationRoot =>
     // given a pre-installed IntelliJ and an IntelliJProvider
-    val preInstalledPlugins = installationRoot.resolve("plugins").directChildren().toSet
+    val preInstalledPlugins = installationRoot.resolve("user-plugins").directChildren().toSet
 
     val config = Config.fromString(s"""
       |probe.intellij {
@@ -97,7 +97,7 @@ final class IntelliJProviderTest {
     val fixture = IntelliJFixture.fromConfig(config)
 
     val existingIntelliJ = fixture.installIntelliJ()
-    val installedPlugins = existingIntelliJ.paths.bundledPlugins.directChildren().toSet
+    val installedPlugins = existingIntelliJ.paths.plugins.directChildren().toSet
 
     assert(installedPlugins.diff(preInstalledPlugins).nonEmpty, "No plugins were installed.")
 
@@ -105,7 +105,7 @@ final class IntelliJProviderTest {
     existingIntelliJ.cleanup()
 
     // then plugins after cleanup should be the same as initially
-    val pluginsAfterCleanup = existingIntelliJ.paths.bundledPlugins.directChildren().toSet
+    val pluginsAfterCleanup = existingIntelliJ.paths.plugins.directChildren().toSet
     assert(installedPlugins.diff(pluginsAfterCleanup).nonEmpty, "No plugins were removed during cleanup.")
     assert(
       pluginsAfterCleanup == preInstalledPlugins,
@@ -118,7 +118,7 @@ final class IntelliJProviderTest {
   private def givenInstalledIntelliJ(test: Path => Unit): Unit = {
     val preInstalledIntelliJ = IntelliJProvider.Default.setup()
     val installationRoot = preInstalledIntelliJ.paths.root
-    preInstalledIntelliJ.paths.bundledPlugins
+    preInstalledIntelliJ.paths.plugins
       .resolve("ideprobe")
       .delete() // Removing the ideprobe plugin - to avoid conflicts when installing it in tests.
     try test(installationRoot)

--- a/extensions/scala/driver/src/main/scala/org/virtuslab/ideprobe/scala/ScalaPluginExtension.scala
+++ b/extensions/scala/driver/src/main/scala/org/virtuslab/ideprobe/scala/ScalaPluginExtension.scala
@@ -19,7 +19,7 @@ trait ScalaPluginExtension { this: IdeProbeFixture =>
         // scala plugin. This is why we delete one of them. We declare the scala-library as an
         // optional dependency with config file probePlugin/src/main/resources/META-INF/scala-plugin.xml
         // so that ideprobe plugin can be loaded regardless of the missing scala-library.
-        inteliJ.paths.bundledPlugins.resolve("ideprobe/lib/scala-library.jar").delete()
+        inteliJ.paths.plugins.resolve("ideprobe/lib/scala-library.jar").delete()
       }
   }
 


### PR DESCRIPTION
https://github.com/VirtusLab/git-machete-intellij-plugin/issues/1820

TL;DR it seems that under IntelliJ 2024.1 EAP 5, the approach with saving the plugins alongside bundled plugins directory no longer works. ideprobe-provided plugins aren't loaded at all, crashing the test on socket connection attempt. The likely cause are the changes applied for [IJPL-633](https://youtrack.jetbrains.com/issue/IJPL-633).